### PR TITLE
Two minor changes in IzPackProjectInstaller and RulesEngineImpl

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/binding/IzpackProjectInstaller.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/binding/IzpackProjectInstaller.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class IzpackProjectInstaller implements Serializable
 {
 
-    private List<Listener> listeners;
+    private List<Listener> listeners = new java.util.ArrayList<Listener>();
 
     private List<Panel> panels;
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -144,10 +144,10 @@ public class RulesEngineImpl implements RulesEngine
 
     public void readConditionMap(Map<String, Condition> rules)
     {
-        conditionsmap = rules;
-        for (String key : conditionsmap.keySet())
+	conditionsmap.putAll(rules);
+        for (String key : rules.keySet())
         {
-            Condition condition = conditionsmap.get(key);
+            Condition condition = rules.get(key);
             condition.setInstalldata(installdata);
         }
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Unpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Unpacker.java
@@ -409,7 +409,7 @@ public class Unpacker extends UnpackerBase
             }
 
             // Custom action listener stuff --- afterPacks ----
-//            informListeners(customActions, InstallerListener.AFTER_PACKS, idata, handler, null);
+            informListeners(customActions, InstallerListener.AFTER_PACKS, idata, npacks, handler);
             if (performInterrupted())
             { // Interrupt was initiated; perform it.
                 return;


### PR DESCRIPTION
i noticed that my custom listeners weren't being called when i ran my installer, and so i noticed in the IzpackProjectInstaller class, fillWithDefault() was initializing listeners as an unmodifiable empty list, so when my listeners were added via add(), they weren't being added and thus not being called.
i also noticed in RulesEngineImpl that readConditionMap() was overwriting the previous set of conditions by calling "conditionsmap = rules" instead of appending the rules via putAll, so i made that change.
