### PR TITLE
4.3 Cosmetic corrections in langpacks

### DIFF
--- a/bin/langpacks/installer/cat.xml
+++ b/bin/langpacks/installer/cat.xml
@@ -104,5 +104,7 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Error" />
+    <str id="data.validation.warning.title" txt="Atenció" />
 </langpack>
 

--- a/bin/langpacks/installer/chn.xml
+++ b/bin/langpacks/installer/chn.xml
@@ -148,5 +148,7 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="´íÎó" />
+    <str id="data.validation.warning.title" txt="¾¯¸æ" />
 </langpack>
 

--- a/bin/langpacks/installer/cze.xml
+++ b/bin/langpacks/installer/cze.xml
@@ -162,4 +162,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Chyba" />
+    <str id="data.validation.warning.title" txt="Varování" />
 </langpack>

--- a/bin/langpacks/installer/dan.xml
+++ b/bin/langpacks/installer/dan.xml
@@ -143,4 +143,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Fejl" />
+    <str id="data.validation.warning.title" txt="Advarsel" />
 </langpack>

--- a/bin/langpacks/installer/deu.xml
+++ b/bin/langpacks/installer/deu.xml
@@ -282,5 +282,8 @@
     <str id="InstallationGroupPanel.colNameSize" txt="Größe"/>
 
     <str id="debug.changevariable" txt="Wert ändern"/>
+        
+    <str id="data.validation.error.title" txt="Fehler" />
+    <str id="data.validation.warning.title" txt="Warnung" />
 </langpack>
 

--- a/bin/langpacks/installer/ell.xml
+++ b/bin/langpacks/installer/ell.xml
@@ -186,4 +186,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Έξοδος" />
+    <str id="data.validation.warning.title" txt="Προσοχή" />
 </langpack>

--- a/bin/langpacks/installer/eng.xml
+++ b/bin/langpacks/installer/eng.xml
@@ -285,4 +285,6 @@
     <str id="log.error_0" txt="unable to write ''{0}''"/>
     <str id="debug.changevariable" txt="modify value"/>
 		
+    <str id="data.validation.error.title" txt="Error" />
+    <str id="data.validation.warning.title" txt="Warning" />
 </langpack>

--- a/bin/langpacks/installer/eus.xml
+++ b/bin/langpacks/installer/eus.xml
@@ -293,4 +293,6 @@
     <str id="log.error_0" txt="unable to write ''{0}''"/>
     <str id="debug.changevariable" txt="modify value"/>
 		
+    <str id="data.validation.error.title" txt="Errorea" />
+    <str id="data.validation.warning.title" txt="Adi" />
 </langpack>

--- a/bin/langpacks/installer/fa.xml
+++ b/bin/langpacks/installer/fa.xml
@@ -260,4 +260,6 @@
 
     <str id="log.error_0" txt="قادر به نوشتن ''{0}'' نیست."/>
 
+    <str id="data.validation.error.title" txt="خطا" />
+    <str id="data.validation.warning.title" txt="هشدار" />
 </langpack>

--- a/bin/langpacks/installer/fin.xml
+++ b/bin/langpacks/installer/fin.xml
@@ -290,4 +290,6 @@
     <str id="log.error_0" txt="ei voi kirjoittaa: ''{0}''"/>
     <str id="debug.changevariable" txt="muuta arvo"/>
 
+    <str id="data.validation.error.title" txt="Virhe" />
+    <str id="data.validation.warning.title" txt="Varoitus" />
 </langpack>

--- a/bin/langpacks/installer/fra.xml
+++ b/bin/langpacks/installer/fra.xml
@@ -285,4 +285,6 @@
     <str id="log.error_0" txt="écriture impossible ''{0}''"/>
 		<str id="debug.changevariable" txt="modification de la valeur"/>
 
+    <str id="data.validation.error.title" txt="Erreur" />
+    <str id="data.validation.warning.title" txt="Attention" />
 </langpack>

--- a/bin/langpacks/installer/glg.xml
+++ b/bin/langpacks/installer/glg.xml
@@ -289,4 +289,6 @@
     <str id="log.error_0" txt="imposible escribir ''{0}''"/>
     <str id="debug.changevariable" txt="modificar valor"/>
  
+    <str id="data.validation.error.title" txt="Erro" />
+    <str id="data.validation.warning.title" txt="Aviso" />
 </langpack>

--- a/bin/langpacks/installer/hun.xml
+++ b/bin/langpacks/installer/hun.xml
@@ -155,4 +155,6 @@
          txt="A program eltávolításához szükséges kulcs a következõ lesz: "/>
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Hiba" />
+    <str id="data.validation.warning.title" txt="Figyelem" />
 </langpack>

--- a/bin/langpacks/installer/ind.xml
+++ b/bin/langpacks/installer/ind.xml
@@ -304,5 +304,8 @@
     <str id="InstallationGroupPanel.colNameSize" txt="Ukuran"/>
 
     <str id="debug.changevariable" txt="ubah nilai"/>
+
+    <str id="data.validation.error.title" txt="Kesalahan" />
+    <str id="data.validation.warning.title" txt="Peringatan" />
 </langpack>
 

--- a/bin/langpacks/installer/ita.xml
+++ b/bin/langpacks/installer/ita.xml
@@ -300,4 +300,7 @@
     <str id="InstallationGroupPanel.colNameSize" txt="Dimensione"/>
 
     <str id="debug.changevariable" txt="modifica valore"/>
+
+    <str id="data.validation.error.title" txt="Errore" />
+    <str id="data.validation.warning.title" txt="Avvertimento" />
 </langpack>

--- a/bin/langpacks/installer/jpn.xml
+++ b/bin/langpacks/installer/jpn.xml
@@ -319,5 +319,7 @@
     <str id="log.error_0" txt="unable to write ''{0}''"/>
     <str id="debug.changevariable" txt="modify value"/>
 
+    <str id="data.validation.error.title" txt="ƒGƒ‰[" />
+    <str id="data.validation.warning.title" txt="Œx " />
 </langpack>
 

--- a/bin/langpacks/installer/kor.xml
+++ b/bin/langpacks/installer/kor.xml
@@ -177,4 +177,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="오류" />
+    <str id="data.validation.warning.title" txt="경고 " />
 </langpack>

--- a/bin/langpacks/installer/mys.xml
+++ b/bin/langpacks/installer/mys.xml
@@ -143,4 +143,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Kesilapan" />
+    <str id="data.validation.warning.title" txt="Amaran" />
 </langpack>

--- a/bin/langpacks/installer/ned.xml
+++ b/bin/langpacks/installer/ned.xml
@@ -360,4 +360,6 @@
          langpack with the same syntax referred as resoure CustomLangpack.xml_[ISO3]"
     -->
 
+    <str id="data.validation.error.title" txt="Fout" />
+    <str id="data.validation.warning.title" txt="Waarschuwing" />
 </langpack>

--- a/bin/langpacks/installer/nor.xml
+++ b/bin/langpacks/installer/nor.xml
@@ -142,4 +142,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Feil" />
+    <str id="data.validation.warning.title" txt="Advarsel" />
 </langpack>

--- a/bin/langpacks/installer/pol.xml
+++ b/bin/langpacks/installer/pol.xml
@@ -31,6 +31,8 @@
 	<str id="CompilePanel.start" txt="Start"/>
 	<str id="CompilePanel.tip" txt="Postęp kompilacji:"/>
 	<str id="ConditionalUserInputPanel.headline" txt="Dane użytkownika"/>
+    <str id="data.validation.error.title" txt="Błąd" />
+    <str id="data.validation.warning.title" txt="Ostrzeżenie" />
 	<str id="debug.changevariable" txt="zmodyfikuj wartość"/>
 	<str id="ExtendedInstallPanel.headline" txt="Instalacja i konfiguracja"/>
 	<str id="FinishPanel.auto" txt="Generuj skrypt automatycznej instalacji"/>

--- a/bin/langpacks/installer/por.xml
+++ b/bin/langpacks/installer/por.xml
@@ -226,4 +226,6 @@
     <str id="nextmedia.choosertitle" txt="Escolha a mídia de instalação"/>
     <str id="nextmedia.filedesc" rdid="pacotes de instalação (.pak*)"/>
 
+    <str id="data.validation.error.title" txt="Erro" />
+    <str id="data.validation.warning.title" txt="Aviso" />
 </langpack>

--- a/bin/langpacks/installer/prt.xml
+++ b/bin/langpacks/installer/prt.xml
@@ -285,4 +285,6 @@
     <str id="log.error_0" txt="unable to write ''{0}''"/>
     <str id="debug.changevariable" txt="modify value"/>
 		
+    <str id="data.validation.error.title" txt="Erro" />
+    <str id="data.validation.warning.title" txt="Aviso" />
 </langpack>

--- a/bin/langpacks/installer/rom.xml
+++ b/bin/langpacks/installer/rom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
 
-<!-- The English langpack -->
+<!-- The Romanian langpack -->
 
 <langpack>
 
@@ -105,4 +105,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Eroare" />
+    <str id="data.validation.warning.title" txt="Atentie" />
 </langpack>

--- a/bin/langpacks/installer/rus.xml
+++ b/bin/langpacks/installer/rus.xml
@@ -181,4 +181,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Ошибка" />
+    <str id="data.validation.warning.title" txt="Предупреждение" />
 </langpack>

--- a/bin/langpacks/installer/scg.xml
+++ b/bin/langpacks/installer/scg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 
-<!-- The English langpack -->
+<!-- The Serbian langpack -->
 
 <langpack>
 
@@ -146,4 +146,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Грешка" />
+    <str id="data.validation.warning.title" txt="Упозорење" />
 </langpack>

--- a/bin/langpacks/installer/spa.xml
+++ b/bin/langpacks/installer/spa.xml
@@ -282,4 +282,7 @@
     <str id="InstallationGroupPanel.colNameSize" txt="Tamaño"/>
 
     <str id="debug.changevariable" txt="Modificar valor"/>
+
+    <str id="data.validation.error.title" txt="Error" />
+    <str id="data.validation.warning.title" txt="Atención" />
 </langpack>

--- a/bin/langpacks/installer/swe.xml
+++ b/bin/langpacks/installer/swe.xml
@@ -174,4 +174,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Fel" />
+    <str id="data.validation.warning.title" txt="Varning" />
 </langpack>

--- a/bin/langpacks/installer/tur.xml
+++ b/bin/langpacks/installer/tur.xml
@@ -186,5 +186,7 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Hata" />
+    <str id="data.validation.warning.title" txt="Uyarı" />
 </langpack>
 

--- a/bin/langpacks/installer/twn.xml
+++ b/bin/langpacks/installer/twn.xml
@@ -162,5 +162,7 @@
     <str id="UserPathPanel.summaryCaption" txt="選擇路徑"/>
     <!-- Strings for the summary of panels - END -->
 
+    <str id="data.validation.error.title" txt="錯誤" />
+    <str id="data.validation.warning.title" txt="警告" />
 </langpack>
 

--- a/bin/langpacks/installer/ukr.xml
+++ b/bin/langpacks/installer/ukr.xml
@@ -5,95 +5,91 @@
 <langpack>
 
     <!-- General installer strings -->
-    <str id="installer.title" txt="IzPack - Ін�?тал�?ці�? "/>
+    <str id="installer.title" txt="IzPack - Інсталяція "/>
     <str id="installer.next" txt="Далі"/>
-    <str id="installer.prev" txt="�?азад"/>
+    <str id="installer.prev" txt="Назад"/>
     <str id="installer.quit" txt="Вийти"/>
-    <str id="installer.madewith" txt="(Ін�?тал�?тор зроблено за допомогою IzPack - http://izpack.org/)"/>
+    <str id="installer.madewith" txt="(Інсталятор зроблено за допомогою IzPack - http://www.izforge.com/)"/>
     <str id="installer.quit.title" txt="Завершити роботу?"/>
-    <str id="installer.quit.message" txt="Ін�?тал�?ці�? буде відмінена !"/>
-    <str id="installer.warning" txt="За�?тереженн�? !"/>
+    <str id="installer.quit.message" txt="Інсталяція буде відмінена !"/>
+    <str id="installer.warning" txt="Застереження !"/>
     <str id="installer.yes" txt="Так"/>
-    <str id="installer.no" txt="�?і"/>
+    <str id="installer.no" txt="Ні"/>
     <str id="installer.cancel" txt="Відмінити"/>
 
     <!-- Uninstaller specific strings -->
-    <str id="uninstaller.warning" txt="Ін�?тальовані програми будуть �?терті !"/>
-    <str id="uninstaller.destroytarget" txt="Деін�?талювати "/>
-    <str id="uninstaller.uninstall" txt="Деін�?талювати в�?тановлені програми"/>
+    <str id="uninstaller.warning" txt="Інстальовані програми будуть стерті !"/>
+    <str id="uninstaller.destroytarget" txt="Деінсталювати "/>
+    <str id="uninstaller.uninstall" txt="Деінсталювати встановлені програми"/>
 
     <!-- The strings for the 'official' IzPack plugins -->
-    <str id="HelloPanel.welcome1" txt="Ла�?каво про�?имо в програму ін�?тал�?ції "/>
+    <str id="HelloPanel.welcome1" txt="Ласкаво просимо в програму інсталяції "/>
     <str id="HelloPanel.welcome2" txt=" !"/>
-    <str id="HelloPanel.authors" txt="�?втори програми: "/>
-    <str id="HelloPanel.url" txt="Домашн�? �?торінка програми: "/>
+    <str id="HelloPanel.authors" txt="Автори програми: "/>
+    <str id="HelloPanel.url" txt="Домашня сторінка програми: "/>
 
-    <str id="LicencePanel.info" txt="Будь ла�?ка уважно прочитайте ліцензію :"/>
+    <str id="LicencePanel.info" txt="Будь ласка уважно прочитайте ліцензію :"/>
     <str id="LicencePanel.agree" txt="Ви згідні з лiцензією ?"/>
     <str id="LicencePanel.notagree" txt="I do not accept the terms of this license agreement."/>
     <str id="LicencePanel.yes" txt="Так"/>
-    <str id="LicencePanel.no" txt="�?і"/>
+    <str id="LicencePanel.no" txt="Ні"/>
 
-    <str id="InfoPanel.info" txt="Будь ла�?ка уважно прочитайте �?лідуючу інформацію :"/>
+    <str id="InfoPanel.info" txt="Будь ласка уважно прочитайте слідуючу інформацію :"/>
 
-    <str id="TargetPanel.info" txt="Виберіть каталог дл�? ін�?тал�?ції :"/>
+    <str id="TargetPanel.info" txt="Виберіть каталог для інсталяції :"/>
     <str id="TargetPanel.browse" txt="Вказати ..."/>
     <str id="TargetPanel.warn"
-         txt="Каталог вже і�?нує ! Бажаєте в�?тановити програму незважаючи на це ?"/>
+         txt="Каталог вже існує ! Бажаєте встановити програму незважаючи на це ?"/>
 
-    <str id="PacksPanel.info" txt="Виберіть пакети дл�? ін�?тал�?ції :"/>
-    <str id="PacksPanel.tip" txt="Примітка: пакети виділені �?ірим кольором необхідні дл�? ін�?тал�?ції."/>
+    <str id="PacksPanel.info" txt="Виберіть пакети для інсталяції :"/>
+    <str id="PacksPanel.tip" txt="Примітка: пакети виділені сірим кольором необхідні для інсталяції."/>
     <str id="PacksPanel.description" txt="Description"/>
 
-    <str id="InstallPanel.info" txt="Підготовка дл�? ін�?тал�?ції програми завершена :"/>
-    <str id="InstallPanel.install" txt="Ін�?талювати !"/>
-    <str id="InstallPanel.tip" txt="По�?туп:"/>
+    <str id="InstallPanel.info" txt="Підготовка для інсталяції програми завершена :"/>
+    <str id="InstallPanel.install" txt="Інсталювати !"/>
+    <str id="InstallPanel.tip" txt="Поступ:"/>
     <str id="InstallPanel.begin" txt="[Порожньо]"/>
     <str id="InstallPanel.finished" txt="[Завершено]"/>
 
-    <str id="FinishPanel.success" txt="Ін�?тал�?ці�? у�?пішно завершена !"/>
-    <str id="FinishPanel.fail" txt="Ін�?тал�?ці�? зазнала аварійного збою ..."/>
-    <str id="FinishPanel.uninst.info" txt="Програма деін�?тал�?ції розміщена в :"/>
-    <str id="FinishPanel.auto" txt="Створити �?ценарій автоматичної ін�?тал�?ції"/>
+    <str id="FinishPanel.success" txt="Інсталяція успішно завершена !"/>
+    <str id="FinishPanel.fail" txt="Інсталяція зазнала аварійного збою ..."/>
+    <str id="FinishPanel.uninst.info" txt="Програма деінсталяції розміщена в :"/>
+    <str id="FinishPanel.auto" txt="Створити сценарій автоматичної інсталяції"/>
     <str id="FinishPanel.auto.tip"
-         txt="Буде �?творено файл, �?ких дозвол�?є автоматично прове�?ти таку �?аму ін�?тал�?цію програми на іншому комп'ютері."/>
+         txt="Буде створено файл, яких дозволяє автоматично провести таку саму інсталяцію програми на іншому комп'ютері."/>
 
-    <str id="ImgPacksPanel.packs" txt="До�?тупні �?лідуючі пакети :"/>
+    <str id="ImgPacksPanel.packs" txt="Доступні слідуючі пакети :"/>
     <str id="ImgPacksPanel.snap" txt="Знимок пакету :"/>
-    <str id="ImgPacksPanel.checkbox" txt=" В�?тановити цей пакет"/>
+    <str id="ImgPacksPanel.checkbox" txt=" Встановити цей пакет"/>
 
-    <str id="ShortcutPanel.regular.list" txt="Виберіть групу програм дл�? по�?илань:"/>
+    <str id="ShortcutPanel.regular.list" txt="Виберіть групу програм для посилань:"/>
     <str id="ShortcutPanel.regular.default" txt="Скинути"/>
-    <str id="ShortcutPanel.regular.desktop" txt="Створити по�?иланн�? на �?тільниці"/>
-    <str id="ShortcutPanel.regular.create" txt="Створити по�?иланн�?"/>
-    <str id="ShortcutPanel.regular.userIntro" txt="�?творенн�? по�?иланн�? дл�?:"/>
-    <str id="ShortcutPanel.regular.currentUser" txt="поточного кори�?тувача"/>
-    <str id="ShortcutPanel.regular.allUsers" txt="в�?іх кори�?тувачів"/>
+    <str id="ShortcutPanel.regular.desktop" txt="Створити посилання на стільниці"/>
+    <str id="ShortcutPanel.regular.create" txt="Створити посилання"/>
+    <str id="ShortcutPanel.regular.userIntro" txt="створення посилання для:"/>
+    <str id="ShortcutPanel.regular.currentUser" txt="поточного користувача"/>
+    <str id="ShortcutPanel.regular.allUsers" txt="всіх користувачів"/>
 
-    <str id="ShortcutPanel.alternate.apology"
-         txt="Вибачте, але IzPack не підтримує �?творенн�? по�?илань дл�? цієї операційної �?и�?теми. Дл�? �?творенн�? по�?илань зверніть�?�? будь-ла�?ка до відповідного по�?ібника кори�?тувача."/>
-    <str id="ShortcutPanel.alternate.targetsLabel"
-         txt="Спи�?ок по�?илань, рекомендованих розробником цього програмного продукту."/>
-    <str id="ShortcutPanel.alternate.textFileExplanation"
-         txt="Ви можете зберегти детальну інформацію про ці по�?иланн�? в тек�?товий файл."/>
-    <str id="ShortcutPanel.alternate.saveButton" txt="Зберегти тек�?товий файл"/>
+    <str id="ShortcutPanel.alternate.apology" txt="Вибачте, але IzPack не підтримує створення посилань для цієї операційної системи. Для створення посилань зверніться будь-ласка до відповідного посібника користувача."/>
+    <str id="ShortcutPanel.alternate.targetsLabel" txt="Список посилань, рекомендованих розробником цього програмного продукту."/>
+    <str id="ShortcutPanel.alternate.textFileExplanation" txt="Ви можете зберегти детальну інформацію про ці посилання в текстовий файл."/>
+    <str id="ShortcutPanel.alternate.saveButton" txt="Зберегти текстовий файл"/>
 
-    <str id="ShortcutPanel.textFile.header"
-         txt="Інформаці�? про по�?иланн�?\n========================\n\n�?ебхідна інформаці�? дл�? �?творенн�? по�?илань вручну.\n"/>
+    <str id="ShortcutPanel.textFile.header" txt="Інформація про посилання\n========================\n\nНебхідна інформація для створення посилань вручну.\n"/>
 
-    <str id="ShortcutPanel.textFile.name" txt="По�?иланн�?         : "/>
-    <str id="ShortcutPanel.textFile.location" txt="Бажане положенн�?  : "/>
-    <str id="ShortcutPanel.textFile.description" txt="Опи�?              : "/>
-    <str id="ShortcutPanel.textFile.target" txt="Ціль по�?иланн�?    : "/>
+    <str id="ShortcutPanel.textFile.name" txt="Посилання         : "/>
+    <str id="ShortcutPanel.textFile.location" txt="Бажане положення  : "/>
+    <str id="ShortcutPanel.textFile.description" txt="Опис              : "/>
+    <str id="ShortcutPanel.textFile.target" txt="Ціль посилання    : "/>
     <str id="ShortcutPanel.textFile.command" txt="Команда виклику   : "/>
     <str id="ShortcutPanel.textFile.iconName" txt="Файл піктограми   : "/>
-    <str id="ShortcutPanel.textFile.iconIndex" txt="Індек�? піктограми : "/>
-    <str id="ShortcutPanel.textFile.work" txt="Каталог виконанн�? : "/>
+    <str id="ShortcutPanel.textFile.iconIndex" txt="Індекс піктограми : "/>
+    <str id="ShortcutPanel.textFile.work" txt="Каталог виконання : "/>
 
-    <str id="ShortcutPanel.location.desktop" txt="Стільниц�?"/>
+    <str id="ShortcutPanel.location.desktop" txt="Стільниця"/>
     <str id="ShortcutPanel.location.applications" txt="Меню програм"/>
-    <str id="ShortcutPanel.location.startMenu" txt="Меню запу�?ку"/>
-    <str id="ShortcutPanel.location.startup" txt="Група запу�?ку"/>
+    <str id="ShortcutPanel.location.startMenu" txt="Меню запуску"/>
+    <str id="ShortcutPanel.location.startup" txt="Група запуску"/>
 
     <str id="UserInputPanel.error.caption" txt="Input Problem"/>
 

--- a/bin/langpacks/installer/ukr.xml
+++ b/bin/langpacks/installer/ukr.xml
@@ -16,6 +16,7 @@
     <str id="installer.yes" txt="Так"/>
     <str id="installer.no" txt="Ні"/>
     <str id="installer.cancel" txt="Відмінити"/>
+    <str id="installer.error" txt="Помилка"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Інстальовані програми будуть стерті !"/>
@@ -95,4 +96,6 @@
 
     <!-- Add your own panels specific strings here if you need -->
 
+    <str id="data.validation.error.title" txt="Помилка" />
+    <str id="data.validation.warning.title" txt="Застереження" />
 </langpack>


### PR DESCRIPTION
The patch includes two commits:
1) Corrected bad characters in the Ukrainian langpack
Seems the file/encoding was corrupted during one of the previous merges

2) Added missing labels for error and warning title in the data validation
panel
We use a custom DataValidator (DB connection settings) and noticed that the title is not available (http://img35.imageshack.us/img35/5107/izpackmissinglabel.png )

Thank in advance!
