### PR TITLE
Added run-with-privileges-on-osx to uninstaller jar

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
@@ -395,6 +395,30 @@ public class UninstallDataWriter
         {
             outJar.putNextEntry(new JarEntry("exec-admin"));
             outJar.closeEntry();
+
+            if (installdata.getRules().isConditionTrue("izpack.macinstall"))
+            {
+                    outJar.putNextEntry(new JarEntry("com/izforge/izpack/installer/run-with-privileges-on-osx"));
+                    InputStream in = getClass().getResourceAsStream("/com/izforge/izpack/installer/run-with-privileges-on-osx");
+                    if (in != null)
+                    {
+                        try
+                        {
+                                byte[] buffer = new byte[1024];
+                                int bytesInBuffer;
+                                while ((bytesInBuffer = in.read(buffer)) != -1)
+                                {
+                                    outJar.write(buffer, 0, bytesInBuffer);
+                                }
+                        }
+                        finally
+                        {
+                                in.close();
+                        }
+                    }
+                    outJar.closeEntry();
+            }
+
         }
 
         // We put the langpack


### PR DESCRIPTION
if you configured the uninstaller to run with privileges, i noticed that the uninstaller writer wasn't writing out the run-with-privileges-on-osx binary to the jar file required to raise privileges.  this commit has code to do that, include the binary if privileges is requested and if the installer will target mac. 
