### PR TITLE
refreshDynamicVariables before panels processing in console

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
@@ -21,10 +21,25 @@
 
 package com.izforge.izpack.installer.automation;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
 import com.izforge.izpack.api.adaptator.impl.XMLParser;
-import com.izforge.izpack.api.data.*;
+import com.izforge.izpack.api.container.BindeableContainer;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
+import com.izforge.izpack.api.data.Info;
+import com.izforge.izpack.api.data.LocaleDatabase;
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.data.ResourceManager;
+import com.izforge.izpack.api.data.ScriptParserConstant;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.installer.DataValidator;
@@ -35,6 +50,7 @@ import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
 import com.izforge.izpack.data.PanelAction;
 import com.izforge.izpack.installer.base.InstallerBase;
 import com.izforge.izpack.installer.console.ConsolePanelAutomationHelper;
+import com.izforge.izpack.installer.container.impl.InstallerContainer.HasInstallerContainer;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.language.ConditionCheck;
 import com.izforge.izpack.installer.manager.DataValidatorFactory;
@@ -42,14 +58,6 @@ import com.izforge.izpack.installer.manager.PanelActionFactory;
 import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.OsConstraintHelper;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TreeMap;
 
 /**
  * Runs the install process in text only (no GUI) mode.
@@ -87,6 +95,8 @@ public class AutomatedInstaller extends InstallerBase
     private UninstallDataWriter uninstallDataWriter;
     private VariableSubstitutor variableSubstitutor;
 
+	private final BindeableContainer installerContainer;
+
     /**
      * Constructing an instance triggers the install.
      *
@@ -94,11 +104,12 @@ public class AutomatedInstaller extends InstallerBase
      * @param resourceManager
      * @throws Exception Description of the Exception
      */
-    public AutomatedInstaller(ResourceManager resourceManager, ConditionCheck checkCondition, UninstallDataWriter uninstallDataWriter, VariableSubstitutor variableSubstitutor)
+    public AutomatedInstaller(ResourceManager resourceManager, ConditionCheck checkCondition, UninstallDataWriter uninstallDataWriter, VariableSubstitutor variableSubstitutor, BindeableContainer installerContainer)
     {
         super(resourceManager);
         this.checkCondition = checkCondition;
         this.uninstallDataWriter = uninstallDataWriter;
+		this.installerContainer = installerContainer;
 
         this.panelInstanceCount = new TreeMap<String, Integer>();
         this.variableSubstitutor = variableSubstitutor;
@@ -356,6 +367,9 @@ public class AutomatedInstaller extends InstallerBase
             }
         }
 
+        if (automationHelperInstance instanceof HasInstallerContainer) {
+        	((HasInstallerContainer) automationHelperInstance).setInstallerContainer(installerContainer);
+        }
         return automationHelperInstance;
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
@@ -93,9 +93,10 @@ public class AutomatedInstaller extends InstallerBase
      * Manager for writing uninstall data
      */
     private UninstallDataWriter uninstallDataWriter;
+
     private VariableSubstitutor variableSubstitutor;
 
-	private final BindeableContainer installerContainer;
+    private final BindeableContainer installerContainer;
 
     /**
      * Constructing an instance triggers the install.
@@ -104,12 +105,14 @@ public class AutomatedInstaller extends InstallerBase
      * @param resourceManager
      * @throws Exception Description of the Exception
      */
-    public AutomatedInstaller(ResourceManager resourceManager, ConditionCheck checkCondition, UninstallDataWriter uninstallDataWriter, VariableSubstitutor variableSubstitutor, BindeableContainer installerContainer)
+    public AutomatedInstaller(ResourceManager resourceManager, ConditionCheck checkCondition,
+            UninstallDataWriter uninstallDataWriter, VariableSubstitutor variableSubstitutor,
+            BindeableContainer installerContainer)
     {
         super(resourceManager);
         this.checkCondition = checkCondition;
         this.uninstallDataWriter = uninstallDataWriter;
-		this.installerContainer = installerContainer;
+        this.installerContainer = installerContainer;
 
         this.panelInstanceCount = new TreeMap<String, Integer>();
         this.variableSubstitutor = variableSubstitutor;
@@ -135,7 +138,7 @@ public class AutomatedInstaller extends InstallerBase
 
         // create the resource manager singleton
         resourceManager.setLocale(this.idata.getLocaleISO3());
-//        ResourceManager.create(this.installData);
+        // ResourceManager.create(this.installData);
     }
 
     @Override
@@ -184,11 +187,13 @@ public class AutomatedInstaller extends InstallerBase
                 if (p.hasCondition()
                         && !rules.isConditionTrue(p.getCondition(), this.idata.getVariables()))
                 {
-                    Debug.log("Condition for panel " + p.getPanelid() + "is not fulfilled, skipping panel!");
+                    Debug.log("Condition for panel " + p.getPanelid()
+                            + "is not fulfilled, skipping panel!");
                     if (this.panelInstanceCount.containsKey(p.className))
                     {
                         // get number of panel instance to process
-                        this.panelInstanceCount.put(p.className, this.panelInstanceCount.get(p.className) + 1);
+                        this.panelInstanceCount.put(p.className,
+                                this.panelInstanceCount.get(p.className) + 1);
                     }
                     else
                     {
@@ -249,8 +254,8 @@ public class AutomatedInstaller extends InstallerBase
                 System.out.println("[ There are file operations pending after reboot ]");
                 switch (idata.getInfo().getRebootAction())
                 {
-                    case Info.REBOOT_ACTION_ALWAYS:
-                        reboot = true;
+                case Info.REBOOT_ACTION_ALWAYS:
+                    reboot = true;
                 }
                 if (reboot)
                 {
@@ -264,23 +269,24 @@ public class AutomatedInstaller extends InstallerBase
     /**
      * Run the installation logic for a panel.
      *
-     * @param p                The panel to install.
+     * @param p The panel to install.
      * @param automationHelper The helper of the panel.
-     * @param panelRoot        The xml element describing the panel.
-     * @throws com.izforge.izpack.api.exception.InstallerException
-     *          if something went wrong while installing.
+     * @param panelRoot The xml element describing the panel.
+     * @throws com.izforge.izpack.api.exception.InstallerException if something went wrong while
+     * installing.
      */
-    private void installPanel(Panel p, PanelAutomation automationHelper, IXMLElement panelRoot) throws InstallerException
+    private void installPanel(Panel p, PanelAutomation automationHelper, IXMLElement panelRoot)
+            throws InstallerException
     {
         executePreActivateActions(p, null);
 
-        Debug.log("automationHelperInstance.runAutomated :"
-                + automationHelper.getClass().getName() + " entered.");
+        Debug.log("automationHelperInstance.runAutomated :" + automationHelper.getClass().getName()
+                + " entered.");
 
         automationHelper.runAutomated(this.idata, panelRoot);
 
-        Debug.log("automationHelperInstance.runAutomated :"
-                + automationHelper.getClass().getName() + " successfully done.");
+        Debug.log("automationHelperInstance.runAutomated :" + automationHelper.getClass().getName()
+                + " successfully done.");
 
         executePreValidateActions(p, null);
         validatePanel(p);
@@ -339,7 +345,8 @@ public class AutomatedInstaller extends InstallerBase
         {
             Debug.log("AutomationHelper:" + automationHelperClassName);
             // determine if the panel supports automated install
-            automationHelperClass = (Class<PanelAutomation>) Class.forName(automationHelperClassName);
+            automationHelperClass = (Class<PanelAutomation>) Class
+                    .forName(automationHelperClassName);
         }
         catch (ClassNotFoundException e)
         {
@@ -359,16 +366,20 @@ public class AutomatedInstaller extends InstallerBase
             }
             catch (IllegalAccessException e)
             {
-                Debug.log("ERROR: no default constructor for " + automationHelperClassName + ", skipping...");
+                Debug.log("ERROR: no default constructor for " + automationHelperClassName
+                        + ", skipping...");
             }
             catch (InstantiationException e)
             {
-                Debug.log("ERROR: no default constructor for " + automationHelperClassName + ", skipping...");
+                Debug.log("ERROR: no default constructor for " + automationHelperClassName
+                        + ", skipping...");
             }
         }
 
-        if (automationHelperInstance instanceof HasInstallerContainer) {
-        	((HasInstallerContainer) automationHelperInstance).setInstallerContainer(installerContainer);
+        if (automationHelperInstance instanceof HasInstallerContainer)
+        {
+            ((HasInstallerContainer) automationHelperInstance)
+                    .setInstallerContainer(installerContainer);
         }
         return automationHelperInstance;
     }
@@ -377,15 +388,14 @@ public class AutomatedInstaller extends InstallerBase
      * Validate a panel.
      *
      * @param p The panel to validate
-     * @throws com.izforge.izpack.api.exception.InstallerException
-     *          thrown if the validation fails.
+     * @throws com.izforge.izpack.api.exception.InstallerException thrown if the validation fails.
      */
     private void validatePanel(final Panel p) throws InstallerException
     {
         try
         {
-            InstallerBase.refreshDynamicVariables(this.idata,
-                    new VariableSubstitutorImpl(this.idata.getVariables()));
+            InstallerBase.refreshDynamicVariables(this.idata, new VariableSubstitutorImpl(
+                    this.idata.getVariables()));
         }
         catch (Exception e)
         {
@@ -393,7 +403,8 @@ public class AutomatedInstaller extends InstallerBase
         }
 
         // Evaluate all global dynamic conditions
-        List<DynamicInstallerRequirementValidator> dynConds = idata.getDynamicinstallerrequirements();
+        List<DynamicInstallerRequirementValidator> dynConds = idata
+                .getDynamicinstallerrequirements();
         if (dynConds != null)
         {
             for (DynamicInstallerRequirementValidator validator : dynConds)
@@ -405,8 +416,9 @@ public class AutomatedInstaller extends InstallerBase
                     try
                     {
                         errorMessage = idata.getLangpack().getString("data.validation.error.title")
-                                + ": " + variableSubstitutor.substitute(idata.getLangpack().getString(validator
-                                .getErrorMessageId()));
+                                + ": "
+                                + variableSubstitutor.substitute(idata.getLangpack().getString(
+                                        validator.getErrorMessageId()));
                     }
                     catch (Exception e)
                     {
@@ -437,8 +449,9 @@ public class AutomatedInstaller extends InstallerBase
                 try
                 {
                     errorMessage = idata.getLangpack().getString("data.validation.error.title")
-                            + ": " + variableSubstitutor.substitute(idata.getLangpack().getString(validator
-                            .getErrorMessageId()));
+                            + ": "
+                            + variableSubstitutor.substitute(idata.getLangpack().getString(
+                                    validator.getErrorMessageId()));
                 }
                 catch (Exception e)
                 {
@@ -505,8 +518,8 @@ public class AutomatedInstaller extends InstallerBase
 
     private void executePreConstructActions(Panel panel, AbstractUIHandler handler)
     {
-        List<PanelAction> preConstructActions = createPanelActionsFromStringList(panel, panel
-                .getPreConstructionActions());
+        List<PanelAction> preConstructActions = createPanelActionsFromStringList(panel,
+                panel.getPreConstructionActions());
         if (preConstructActions != null)
         {
             for (PanelAction preConstructAction : preConstructActions)
@@ -518,8 +531,8 @@ public class AutomatedInstaller extends InstallerBase
 
     private void executePreActivateActions(Panel panel, AbstractUIHandler handler)
     {
-        List<PanelAction> preActivateActions = createPanelActionsFromStringList(panel, panel
-                .getPreActivationActions());
+        List<PanelAction> preActivateActions = createPanelActionsFromStringList(panel,
+                panel.getPreActivationActions());
         if (preActivateActions != null)
         {
             for (PanelAction preActivateAction : preActivateActions)
@@ -531,8 +544,8 @@ public class AutomatedInstaller extends InstallerBase
 
     private void executePreValidateActions(Panel panel, AbstractUIHandler handler)
     {
-        List<PanelAction> preValidateActions = createPanelActionsFromStringList(panel, panel
-                .getPreValidationActions());
+        List<PanelAction> preValidateActions = createPanelActionsFromStringList(panel,
+                panel.getPreValidationActions());
         if (preValidateActions != null)
         {
             for (PanelAction preValidateAction : preValidateActions)
@@ -544,8 +557,8 @@ public class AutomatedInstaller extends InstallerBase
 
     private void executePostValidateActions(Panel panel, AbstractUIHandler handler)
     {
-        List<PanelAction> postValidateActions = createPanelActionsFromStringList(panel, panel
-                .getPostValidationActions());
+        List<PanelAction> postValidateActions = createPanelActionsFromStringList(panel,
+                panel.getPostValidationActions());
         if (postValidateActions != null)
         {
             for (PanelAction postValidateAction : postValidateActions)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -21,17 +21,17 @@
 
 package com.izforge.izpack.installer.bootstrap;
 
+import java.awt.GraphicsEnvironment;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 import com.izforge.izpack.installer.automation.AutomatedInstaller;
 import com.izforge.izpack.installer.console.ConsoleInstaller;
 import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.StringTool;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.awt.GraphicsEnvironment;
 
 /**
  * The program entry point. Selects between GUI and text install modes.
@@ -42,17 +42,18 @@ public class Installer
 {
 
     public static final int INSTALLER_GUI = 0, INSTALLER_AUTO = 1, INSTALLER_CONSOLE = 2;
-    public static final int CONSOLE_INSTALL = 0, CONSOLE_GEN_TEMPLATE = 1, CONSOLE_FROM_TEMPLATE = 2,
-            CONSOLE_FROM_SYSTEMPROPERTIES = 3, CONSOLE_FROM_SYSTEMPROPERTIESMERGE = 4;
+
+    public static final int CONSOLE_INSTALL = 0, CONSOLE_GEN_TEMPLATE = 1,
+            CONSOLE_FROM_TEMPLATE = 2, CONSOLE_FROM_SYSTEMPROPERTIES = 3,
+            CONSOLE_FROM_SYSTEMPROPERTIESMERGE = 4;
 
     private InstallerContainer applicationComponent;
 
-
     /*
-    * The main method (program entry point).
-    *
-    * @param args The arguments passed on the command-line.
-    */
+     * The main method (program entry point).
+     *
+     * @param args The arguments passed on the command-line.
+     */
 
     public static void main(String[] args)
     {
@@ -73,7 +74,6 @@ public class Installer
         applicationComponent = new InstallerContainer();
         applicationComponent.initBindings();
     }
-
 
     private void start(String[] args)
     {
@@ -158,34 +158,37 @@ public class Installer
         }
     }
 
-    private void launchInstall(int type, int consoleAction, String path, String langcode) throws Exception
+    private void launchInstall(int type, int consoleAction, String path, String langcode)
+            throws Exception
     {
         // if headless, just use the console mode
-        if (type == INSTALLER_GUI && GraphicsEnvironment.isHeadless()) 
+        if (type == INSTALLER_GUI && GraphicsEnvironment.isHeadless())
         {
             type = INSTALLER_CONSOLE;
         }
-        
+
         switch (type)
         {
-            case INSTALLER_GUI:
-                InstallerGui.run();
-                break;
+        case INSTALLER_GUI:
+            InstallerGui.run();
+            break;
 
-            case INSTALLER_AUTO:
-                initContainer();
-                AutomatedInstaller automatedInstaller = applicationComponent.getComponent(AutomatedInstaller.class);
-                automatedInstaller.init(path);
-                automatedInstaller.doInstall();
-                break;
+        case INSTALLER_AUTO:
+            initContainer();
+            AutomatedInstaller automatedInstaller = applicationComponent
+                    .getComponent(AutomatedInstaller.class);
+            automatedInstaller.init(path);
+            automatedInstaller.doInstall();
+            break;
 
-            case INSTALLER_CONSOLE:
-            	System.setProperty("java.awt.headless", "true");
-                initContainer();
-                ConsoleInstaller consoleInstaller = applicationComponent.getComponent(ConsoleInstaller.class);
-                consoleInstaller.setLangCode(langcode);
-                consoleInstaller.run(consoleAction, path);
-                break;
+        case INSTALLER_CONSOLE:
+            System.setProperty("java.awt.headless", "true");
+            initContainer();
+            ConsoleInstaller consoleInstaller = applicationComponent
+                    .getComponent(ConsoleInstaller.class);
+            consoleInstaller.setLangCode(langcode);
+            consoleInstaller.run(consoleAction, path);
+            break;
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -180,6 +180,7 @@ public class Installer
                 break;
 
             case INSTALLER_CONSOLE:
+            	System.setProperty("java.awt.headless", "true");
                 initContainer();
                 ConsoleInstaller consoleInstaller = applicationComponent.getComponent(ConsoleInstaller.class);
                 consoleInstaller.setLangCode(langcode);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -66,21 +66,26 @@ public class ConsoleInstaller extends InstallerBase
     private Properties properties;
 
     private PrintWriter printWriter;
+
     private final RulesEngine rules;
+
     private ConditionCheck checkCondition;
+
     private VariableSubstitutor variableSubstitutor;
 
-	private final BindeableContainer installerContainer;
+    private final BindeableContainer installerContainer;
 
-    public ConsoleInstaller(AutomatedInstallData installdata, RulesEngine rules, ResourceManager resourceManager, ConditionCheck checkCondition, BindeableContainer installerContainer) throws Exception
+    public ConsoleInstaller(AutomatedInstallData installdata, RulesEngine rules,
+            ResourceManager resourceManager, ConditionCheck checkCondition,
+            BindeableContainer installerContainer) throws Exception
 
     {
         super(resourceManager);
-//        super(resourceManager);
+        // super(resourceManager);
         this.checkCondition = checkCondition;
         this.installdata = installdata;
         this.rules = rules;
-		this.installerContainer = installerContainer;
+        this.installerContainer = installerContainer;
 
         // Fallback: choose the first listed language pack if not specified via commandline
         if (this.installdata.getLocaleISO3() == null)
@@ -88,9 +93,11 @@ public class ConsoleInstaller extends InstallerBase
             this.installdata.setLocaleISO3(resourceManager.getAvailableLangPacks().get(0));
         }
 
-        InputStream in = resourceManager.getInputStream("langpacks/" + this.installdata.getLocaleISO3() + ".xml");
+        InputStream in = resourceManager.getInputStream("langpacks/"
+                + this.installdata.getLocaleISO3() + ".xml");
         this.installdata.setLangpack(new LocaleDatabase(in));
-        this.installdata.setVariable(ScriptParserConstant.ISO3_LANG, this.installdata.getLocaleISO3());
+        this.installdata.setVariable(ScriptParserConstant.ISO3_LANG,
+                this.installdata.getLocaleISO3());
         resourceManager.setLocale(this.installdata.getLocaleISO3());
         if (!checkCondition.checkInstallerRequirements(this))
         {
@@ -116,8 +123,9 @@ public class ConsoleInstaller extends InstallerBase
         }
         Debug.log("[ Starting console installation ] " + strAction);
 
-        VariableSubstitutorImpl substitutor = new VariableSubstitutorImpl(this.installdata.getVariables());
-		refreshDynamicVariables(this.installdata, substitutor);
+        VariableSubstitutorImpl substitutor = new VariableSubstitutorImpl(
+                this.installdata.getVariables());
+        refreshDynamicVariables(this.installdata, substitutor);
         try
         {
             this.result = true;
@@ -133,10 +141,10 @@ public class ConsoleInstaller extends InstallerBase
 
                 PanelConsole consoleHelperInstance = getPanelConsoleHelper(panel);
 
-                //Check to see if we can show the panel based on its conditions.
+                // Check to see if we can show the panel based on its conditions.
                 if ((consoleHelperInstance != null) && (canShow(panel)))
                 {
-                	String consoleHelperClassName = consoleHelperInstance.getClass().getName();
+                    String consoleHelperClassName = consoleHelperInstance.getClass().getName();
                     try
                     {
                         Debug.log("consoleHelperInstance." + strAction + ":"
@@ -147,8 +155,7 @@ public class ConsoleInstaller extends InstallerBase
                         if (strCondition != null)
                         {
                             RulesEngine rules = installdata.getRules();
-                            bIsConditionFulfilled = rules.isConditionTrue(
-                                    strCondition);
+                            bIsConditionFulfilled = rules.isConditionTrue(strCondition);
                         }
 
                         if (strAction.equals("doInstall") && bIsConditionFulfilled)
@@ -220,22 +227,22 @@ public class ConsoleInstaller extends InstallerBase
 
     }
 
-    private PanelConsole getPanelConsoleHelper(Panel panel) {
+    private PanelConsole getPanelConsoleHelper(Panel panel)
+    {
         String prefix = "com.izforge.izpack.panels.";
         if (panel.className.contains("."))
         {
             prefix = "";
         }
 
-    	String panelClassName = panel.className;
+        String panelClassName = panel.className;
         String consoleHelperClassName = prefix + panelClassName + "ConsoleHelper";
         Class<PanelConsole> consoleHelperClass = null;
 
         Debug.log("ConsoleHelper:" + consoleHelperClassName);
         try
         {
-            consoleHelperClass = (Class<PanelConsole>) Class
-                    .forName(consoleHelperClassName);
+            consoleHelperClass = (Class<PanelConsole>) Class.forName(consoleHelperClassName);
         }
         catch (ClassNotFoundException e)
         {
@@ -257,13 +264,15 @@ public class ConsoleInstaller extends InstallerBase
             }
         }
 
-        if (consoleHelperInstance instanceof HasInstallerContainer) {
-        	((HasInstallerContainer) consoleHelperInstance).setInstallerContainer(installerContainer);
+        if (consoleHelperInstance instanceof HasInstallerContainer)
+        {
+            ((HasInstallerContainer) consoleHelperInstance)
+                    .setInstallerContainer(installerContainer);
         }
         return consoleHelperInstance;
-	}
+    }
 
-	protected void doInstall() throws Exception
+    protected void doInstall() throws Exception
     {
         try
         {
@@ -337,7 +346,6 @@ public class ConsoleInstaller extends InstallerBase
         }
     }
 
-
     /**
      * Method checks whether conditions are met to show the given panel.
      *
@@ -370,20 +378,19 @@ public class ConsoleInstaller extends InstallerBase
         }
     }
 
-
     /**
      * Validate a panel.
      *
      * @param p The panel to validate
-     * @return The status of the validation - false makes the installation fail
-     *         thrown if the validation fails.
+     * @return The status of the validation - false makes the installation fail thrown if the
+     * validation fails.
      */
     private boolean validatePanel(final Panel p) throws InstallerException
     {
         try
         {
-            InstallerBase.refreshDynamicVariables(installdata,
-                    new VariableSubstitutorImpl(this.installdata.getVariables()));
+            InstallerBase.refreshDynamicVariables(installdata, new VariableSubstitutorImpl(
+                    this.installdata.getVariables()));
         }
         catch (Exception e)
         {
@@ -391,7 +398,8 @@ public class ConsoleInstaller extends InstallerBase
         }
 
         // Evaluate all global dynamic conditions
-        List<DynamicInstallerRequirementValidator> dynConds = installdata.getDynamicinstallerrequirements();
+        List<DynamicInstallerRequirementValidator> dynConds = installdata
+                .getDynamicinstallerrequirements();
         if (dynConds != null)
         {
             for (DynamicInstallerRequirementValidator validator : dynConds)
@@ -402,9 +410,11 @@ public class ConsoleInstaller extends InstallerBase
                     String errorMessage;
                     try
                     {
-                        errorMessage = installdata.getLangpack().getString("data.validation.error.title")
-                                + ": " + variableSubstitutor.substitute(installdata.getLangpack().getString(validator
-                                .getErrorMessageId()));
+                        errorMessage = installdata.getLangpack().getString(
+                                "data.validation.error.title")
+                                + ": "
+                                + variableSubstitutor.substitute(installdata.getLangpack()
+                                        .getString(validator.getErrorMessageId()));
                     }
                     catch (Exception e)
                     {
@@ -457,9 +467,8 @@ public class ConsoleInstaller extends InstallerBase
             String oldval = (String) properties.setProperty(key, newval);
             if (oldval != null)
             {
-                System.out.println(
-                        "Warning: Property " + key + " overwritten: '"
-                                + oldval + "' --> '" + newval + "'");
+                System.out.println("Warning: Property " + key + " overwritten: '" + oldval
+                        + "' --> '" + newval + "'");
             }
         }
     }
@@ -473,8 +482,8 @@ public class ConsoleInstaller extends InstallerBase
             System.out.println("[ There are file operations pending after reboot ]");
             switch (installdata.getInfo().getRebootAction())
             {
-                case Info.REBOOT_ACTION_ALWAYS:
-                    reboot = true;
+            case Info.REBOOT_ACTION_ALWAYS:
+                reboot = true;
             }
             if (reboot)
             {
@@ -488,24 +497,24 @@ public class ConsoleInstaller extends InstallerBase
     {
         switch (type)
         {
-            case Installer.CONSOLE_GEN_TEMPLATE:
-                doGeneratePropertiesFile(path);
-                break;
+        case Installer.CONSOLE_GEN_TEMPLATE:
+            doGeneratePropertiesFile(path);
+            break;
 
-            case Installer.CONSOLE_FROM_TEMPLATE:
-                doInstallFromPropertiesFile(path);
-                break;
+        case Installer.CONSOLE_FROM_TEMPLATE:
+            doInstallFromPropertiesFile(path);
+            break;
 
-            case Installer.CONSOLE_FROM_SYSTEMPROPERTIES:
-                doInstallFromSystemProperties();
-                break;
+        case Installer.CONSOLE_FROM_SYSTEMPROPERTIES:
+            doInstallFromSystemProperties();
+            break;
 
-            case Installer.CONSOLE_FROM_SYSTEMPROPERTIESMERGE:
-                doInstallFromSystemPropertiesMerge(path);
-                break;
+        case Installer.CONSOLE_FROM_SYSTEMPROPERTIESMERGE:
+            doInstallFromSystemPropertiesMerge(path);
+            break;
 
-            default:
-                doInstall();
+        default:
+            doInstall();
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -110,6 +110,8 @@ public class ConsoleInstaller extends InstallerBase
         }
         Debug.log("[ Starting console installation ] " + strAction);
 
+        VariableSubstitutorImpl substitutor = new VariableSubstitutorImpl(this.installdata.getVariables());
+		refreshDynamicVariables(this.installdata, substitutor);
         try
         {
             this.result = true;
@@ -221,8 +223,7 @@ public class ConsoleInstaller extends InstallerBase
 
                 }
 
-                refreshDynamicVariables(this.installdata,
-                        new VariableSubstitutorImpl(this.installdata.getVariables()));
+                refreshDynamicVariables(this.installdata, substitutor);
             }
 
             if (this.result)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,48 +25,44 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.substitutor.VariableSubstitutor;
+import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
+
 /**
  * Abstract class implementing basic functions needed by all panel console helpers.
  *
  * @author Mounir El Hajj
  */
-abstract public class PanelConsoleHelper
-{
+abstract public class PanelConsoleHelper {
 
+	private VariableSubstitutor variableSubstitutor;
 
-    public int askEndOfConsolePanel()
-    {
-        try
-        {
-            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-            while (true)
-            {
-                System.out.println("press 1 to continue, 2 to quit, 3 to redisplay");
-                String strIn = br.readLine();
-                if (strIn.equals("1"))
-                {
-                    return 1;
-                }
-                else if (strIn.equals("2"))
-                {
-                    return 2;
-                }
-                else if (strIn.equals("3"))
-                {
-                    return 3;
-                }
-                else if (strIn.equals("3"))
-                {
-                    return 3;
-                }
-            }
+	public int askEndOfConsolePanel() {
+		try {
+			BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+			while (true) {
+				System.out.println("press 1 to continue, 2 to quit, 3 to redisplay");
+				String strIn = br.readLine();
+				if (strIn.equals("1")) {
+					return 1;
+				} else if (strIn.equals("2")) {
+					return 2;
+				} else if (strIn.equals("3")) {
+					return 3;
+				} else if (strIn.equals("3")) {
+					return 3;
+				}
+			}
 
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-        return 2;
-    }
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return 2;
+	}
 
+	protected final VariableSubstitutor getVariableSubstitutor(AutomatedInstallData installData) {
+		if (variableSubstitutor == null) variableSubstitutor = new VariableSubstitutorImpl(installData.getVariables());
+		return variableSubstitutor;
+	}
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
@@ -38,86 +38,110 @@ import com.izforge.izpack.util.Housekeeper;
  * @see PanelAutomationHelper
  * @author Mounir El Hajj
  */
-abstract public class PanelConsoleHelper implements AbstractUIHandler {
+abstract public class PanelConsoleHelper implements AbstractUIHandler
+{
 
-	private VariableSubstitutor variableSubstitutor;
+    private VariableSubstitutor variableSubstitutor;
 
-	public int askEndOfConsolePanel() {
-		try {
-			BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-			while (true) {
-				System.out.println("press 1 to continue, 2 to quit, 3 to redisplay");
-				String strIn = br.readLine();
-				if (strIn.equals("1")) {
-					return 1;
-				} else if (strIn.equals("2")) {
-					return 2;
-				} else if (strIn.equals("3")) {
-					return 3;
-				} else if (strIn.equals("3")) {
-					return 3;
-				}
-			}
+    public int askEndOfConsolePanel()
+    {
+        try
+        {
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            while (true)
+            {
+                System.out.println("press 1 to continue, 2 to quit, 3 to redisplay");
+                String strIn = br.readLine();
+                if (strIn.equals("1"))
+                {
+                    return 1;
+                }
+                else if (strIn.equals("2"))
+                {
+                    return 2;
+                }
+                else if (strIn.equals("3"))
+                {
+                    return 3;
+                }
+                else if (strIn.equals("3")) { return 3; }
+            }
 
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return 2;
-	}
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+        return 2;
+    }
 
-	protected final VariableSubstitutor getVariableSubstitutor(AutomatedInstallData installData) {
-		if (variableSubstitutor == null) variableSubstitutor = new VariableSubstitutorImpl(installData.getVariables());
-		return variableSubstitutor;
-	}
+    protected final VariableSubstitutor getVariableSubstitutor(AutomatedInstallData installData)
+    {
+        if (variableSubstitutor == null)
+            variableSubstitutor = new VariableSubstitutorImpl(installData.getVariables());
+        return variableSubstitutor;
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitNotification(java.lang.String)
-	 */
-	public void emitNotification(String message) {
-		System.out.println(message);
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitNotification(java.lang.String)
+     */
+    public void emitNotification(String message)
+    {
+        System.out.println(message);
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitWarning(java.lang.String, java.lang.String)
-	 */
-	public boolean emitWarning(String title, String message) {
-		System.err.println("[ WARNING: " + formatTitle(title) + message + " ]");
-		// default: continue
-		return true;
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitWarning(java.lang.String,
+     * java.lang.String)
+     */
+    public boolean emitWarning(String title, String message)
+    {
+        System.err.println("[ WARNING: " + formatTitle(title) + message + " ]");
+        // default: continue
+        return true;
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitError(java.lang.String, java.lang.String)
-	 */
-	public void emitError(String title, String message) {
-		System.err.println("[ ERROR: " + formatTitle(title) + message + " ]");
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitError(java.lang.String,
+     * java.lang.String)
+     */
+    public void emitError(String title, String message)
+    {
+        System.err.println("[ ERROR: " + formatTitle(title) + message + " ]");
+    }
 
-	private String formatTitle(String title) {
-		if (title == null || title.isEmpty()) return "";
-		return title + ": ";
-	}
+    private String formatTitle(String title)
+    {
+        if (title == null || title.isEmpty()) return "";
+        return title + ": ";
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitErrorAndBlockNext(java.lang.String, java.lang.String)
-	 */
-	public void emitErrorAndBlockNext(String title, String message) {
-		emitError(title, message);
-		Housekeeper.getInstance().shutDown(10);
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitErrorAndBlockNext(java.lang.String,
+     * java.lang.String)
+     */
+    public void emitErrorAndBlockNext(String title, String message)
+    {
+        emitError(title, message);
+        Housekeeper.getInstance().shutDown(10);
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String, java.lang.String, int)
-	 */
-	public int askQuestion(String title, String question, int choices) {
-		// don't know what to answer
-		return AbstractUIHandler.ANSWER_CANCEL;
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String,
+     * java.lang.String, int)
+     */
+    public int askQuestion(String title, String question, int choices)
+    {
+        // don't know what to answer
+        return AbstractUIHandler.ANSWER_CANCEL;
+    }
 
-	/**
-	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String, java.lang.String, int, int)
-	 */
-	public int askQuestion(String title, String question, int choices, int default_choice) {
-		return default_choice;
-	}
+    /**
+     * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String,
+     * java.lang.String, int, int)
+     */
+    public int askQuestion(String title, String question, int choices, int default_choice)
+    {
+        return default_choice;
+    }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
@@ -26,15 +26,19 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
+import com.izforge.izpack.installer.automation.PanelAutomationHelper;
+import com.izforge.izpack.util.Housekeeper;
 
 /**
  * Abstract class implementing basic functions needed by all panel console helpers.
  *
+ * @see PanelAutomationHelper
  * @author Mounir El Hajj
  */
-abstract public class PanelConsoleHelper {
+abstract public class PanelConsoleHelper implements AbstractUIHandler {
 
 	private VariableSubstitutor variableSubstitutor;
 
@@ -64,5 +68,56 @@ abstract public class PanelConsoleHelper {
 	protected final VariableSubstitutor getVariableSubstitutor(AutomatedInstallData installData) {
 		if (variableSubstitutor == null) variableSubstitutor = new VariableSubstitutorImpl(installData.getVariables());
 		return variableSubstitutor;
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitNotification(java.lang.String)
+	 */
+	public void emitNotification(String message) {
+		System.out.println(message);
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitWarning(java.lang.String, java.lang.String)
+	 */
+	public boolean emitWarning(String title, String message) {
+		System.err.println("[ WARNING: " + formatTitle(title) + message + " ]");
+		// default: continue
+		return true;
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitError(java.lang.String, java.lang.String)
+	 */
+	public void emitError(String title, String message) {
+		System.err.println("[ ERROR: " + formatTitle(title) + message + " ]");
+	}
+
+	private String formatTitle(String title) {
+		if (title == null || title.isEmpty()) return "";
+		return title + ": ";
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#emitErrorAndBlockNext(java.lang.String, java.lang.String)
+	 */
+	public void emitErrorAndBlockNext(String title, String message) {
+		emitError(title, message);
+		Housekeeper.getInstance().shutDown(10);
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String, java.lang.String, int)
+	 */
+	public int askQuestion(String title, String question, int choices) {
+		// don't know what to answer
+		return AbstractUIHandler.ANSWER_CANCEL;
+	}
+
+	/**
+	 * @see com.izforge.izpack.api.handler.AbstractUIHandler#askQuestion(java.lang.String, java.lang.String, int, int)
+	 */
+	public int askQuestion(String title, String question, int choices, int default_choice) {
+		return default_choice;
 	}
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
@@ -87,9 +87,14 @@ public class InstallerContainer extends AbstractContainer
         }
         pico
                 // Configuration of title parameter in InstallerFrame
-                .addConfig("title", getTitle(installdata, substitutor))
-                        // Configuration of frame parameter in languageDialog
-                .addConfig("frame", initFrame());
+                .addConfig("title", getTitle(installdata, substitutor));
+
+        String headless = System.getProperty("java.awt.headless");
+		if (headless == null || headless.equals("false")) {
+			// Configuration of frame parameter in languageDialog
+			pico.addConfig("frame", initFrame());
+        }
+
         pico
                 .addComponent(IUnpacker.class, unpackerclass)
                 .addComponent(InstallerFrame.class)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
@@ -1,5 +1,16 @@
 package com.izforge.izpack.installer.container.impl;
 
+import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.util.Properties;
+
+import javax.swing.ImageIcon;
+import javax.swing.JFrame;
+
+import org.picocontainer.Characteristics;
+import org.picocontainer.MutablePicoContainer;
+import org.picocontainer.injectors.ProviderAdapter;
+
 import com.izforge.izpack.api.container.BindeableContainer;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.ResourceManager;
@@ -25,13 +36,6 @@ import com.izforge.izpack.installer.language.LanguageDialog;
 import com.izforge.izpack.installer.manager.PanelManager;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
 import com.izforge.izpack.merge.MergeManagerImpl;
-import org.picocontainer.Characteristics;
-import org.picocontainer.MutablePicoContainer;
-import org.picocontainer.injectors.ProviderAdapter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.Properties;
 
 /**
  * Application Component. <br />
@@ -138,4 +142,10 @@ public class InstallerContainer extends AbstractContainer
         return message;
     }
 
+    public interface HasInstallerContainer {
+
+    	BindeableContainer getInstallerContainer();
+
+    	void setInstallerContainer(BindeableContainer installerContainer);
+    }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
@@ -48,27 +48,19 @@ public class InstallerContainer extends AbstractContainer
     {
         this.pico = pico;
         pico
-//              .addAdapter(new ProviderAdapter(new AutomatedInstallDataProvider()))
-                .addAdapter(new ProviderAdapter(new GUIInstallDataProvider()))
+        // .addAdapter(new ProviderAdapter(new AutomatedInstallDataProvider()))
+        .addAdapter(new ProviderAdapter(new GUIInstallDataProvider()))
                 .addAdapter(new ProviderAdapter(new IconsProvider()))
-                .addAdapter(new ProviderAdapter(new RulesProvider()))
-                ;
-        pico
-                .addComponent(PanelManager.class)
-                .addComponent(InstallDataConfiguratorWithRules.class)
-                .addComponent(ConditionCheck.class)
-                .addComponent(InstallerController.class)
-                .addComponent(MergeManagerImpl.class)
-                .addComponent(UninstallData.class)
+                .addAdapter(new ProviderAdapter(new RulesProvider()));
+        pico.addComponent(PanelManager.class).addComponent(InstallDataConfiguratorWithRules.class)
+                .addComponent(ConditionCheck.class).addComponent(InstallerController.class)
+                .addComponent(MergeManagerImpl.class).addComponent(UninstallData.class)
                 .addComponent(MutablePicoContainer.class, pico)
                 .addComponent(ConditionContainer.class)
                 .addComponent(VariableSubstitutor.class, VariableSubstitutorImpl.class)
-                .addComponent(Properties.class)
-                .addComponent(ResourceManager.class)
-                .addComponent(ConsoleInstaller.class)
-                .addComponent(UninstallDataWriter.class)
-                .addComponent(AutomatedInstaller.class)
-                .addComponent(EventFiller.class)
+                .addComponent(Properties.class).addComponent(ResourceManager.class)
+                .addComponent(ConsoleInstaller.class).addComponent(UninstallDataWriter.class)
+                .addComponent(AutomatedInstaller.class).addComponent(EventFiller.class)
                 .addComponent(BindeableContainer.class, this);
 
         new ResolverContainerFiller().fillContainer(pico);
@@ -86,24 +78,22 @@ public class InstallerContainer extends AbstractContainer
             throw new IzPackException(e);
         }
         pico
-                // Configuration of title parameter in InstallerFrame
-                .addConfig("title", getTitle(installdata, substitutor));
+        // Configuration of title parameter in InstallerFrame
+        .addConfig("title", getTitle(installdata, substitutor));
 
         String headless = System.getProperty("java.awt.headless");
-		if (headless == null || headless.equals("false")) {
-			// Configuration of frame parameter in languageDialog
-			pico.addConfig("frame", initFrame());
+        if (headless == null || headless.equals("false"))
+        {
+            // Configuration of frame parameter in languageDialog
+            pico.addConfig("frame", initFrame());
         }
 
-        pico
-                .addComponent(IUnpacker.class, unpackerclass)
-                .addComponent(InstallerFrame.class)
+        pico.addComponent(IUnpacker.class, unpackerclass).addComponent(InstallerFrame.class)
                 .as(Characteristics.USE_NAMES).addComponent(LanguageDialog.class);
 
         // Load custom data in last position
         pico.getComponent(EventFiller.class).loadCustomData();
     }
-
 
     private JFrame initFrame()
     {
@@ -111,7 +101,8 @@ public class InstallerContainer extends AbstractContainer
         // Dummy Frame
         JFrame frame = new JFrame();
         ImageIcon imageIcon;
-        imageIcon = resourceManager.getImageIconResource("JFrameIcon", "/com/izforge/izpack/img/JFrameIcon.png");
+        imageIcon = resourceManager.getImageIconResource("JFrameIcon",
+                "/com/izforge/izpack/img/JFrameIcon.png");
         frame.setIconImage(imageIcon.getImage());
 
         Dimension frameSize = frame.getSize();
@@ -134,7 +125,7 @@ public class InstallerContainer extends AbstractContainer
         }
         else
         { // Attention! The alternate message has to contain the whole message including
-            // $APP_NAME and may be $APP_VER.
+          // $APP_NAME and may be $APP_VER.
             try
             {
                 return vs.substitute(message);
@@ -147,10 +138,11 @@ public class InstallerContainer extends AbstractContainer
         return message;
     }
 
-    public interface HasInstallerContainer {
+    public interface HasInstallerContainer
+    {
 
-    	BindeableContainer getInstallerContainer();
+        BindeableContainer getInstallerContainer();
 
-    	void setInstallerContainer(BindeableContainer installerContainer);
+        void setInstallerContainer(BindeableContainer installerContainer);
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
@@ -36,107 +36,123 @@ import com.izforge.izpack.installer.unpacker.IUnpacker;
  *
  * @author Jonathan Halliday
  */
-public class InstallPanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation, AbstractUIProgressHandler, HasInstallerContainer {
+public class InstallPanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation,
+        AbstractUIProgressHandler, HasInstallerContainer
+{
 
-	private BindeableContainer installerContainer;
-	private int noOfPacks = 0;
+    private BindeableContainer installerContainer;
 
-	/**
-	 * Null op - this panel type has no state to serialize.
-	 *
-	 * @param installData unused.
-	 * @param panelRoot   unused.
-	 */
-	public void makeXMLData(AutomatedInstallData installData, IXMLElement panelRoot) {
-		// do nothing.
-	}
+    private int noOfPacks = 0;
 
-	/**
-	 * Perform the installation actions.
-	 *
-	 * @param panelRoot The panel XML tree root.
-	 * @return true if the installation was successful.
-	 */
-	public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot) throws InstallerException {
-		IUnpacker unpacker = installerContainer.getComponent(IUnpacker.class);
-		unpacker.setHandler(this);
-		Thread unpackerthread = new Thread(unpacker, "IzPack - Unpacker thread");
-		unpacker.setRules(idata.getRules());
-		unpackerthread.start();
-		while (unpackerthread.isAlive()) {
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-				// ignore it, we're waiting for the unpacker to finish...
-			}
-		}
-		if (!unpacker.getResult()) {
-			throw new InstallerException("Unpack failed (xml line " + panelRoot.getLineNr() + ")");
-		}
-	}
+    /**
+     * Null op - this panel type has no state to serialize.
+     *
+     * @param installData unused.
+     * @param panelRoot unused.
+     */
+    public void makeXMLData(AutomatedInstallData installData, IXMLElement panelRoot)
+    {
+        // do nothing.
+    }
 
-	/**
-	 * Reports progress on System.out
-	 *
-	 * @see AbstractUIProgressHandler#startAction(String, int)
-	 */
-	public void startAction(String name, int no_of_steps) {
-		System.out.println("[ Starting to unpack ]");
-		this.noOfPacks = no_of_steps;
-	}
+    /**
+     * Perform the installation actions.
+     *
+     * @param panelRoot The panel XML tree root.
+     * @return true if the installation was successful.
+     */
+    public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot)
+            throws InstallerException
+    {
+        IUnpacker unpacker = installerContainer.getComponent(IUnpacker.class);
+        unpacker.setHandler(this);
+        Thread unpackerthread = new Thread(unpacker, "IzPack - Unpacker thread");
+        unpacker.setRules(idata.getRules());
+        unpackerthread.start();
+        while (unpackerthread.isAlive())
+        {
+            try
+            {
+                Thread.sleep(100);
+            }
+            catch (InterruptedException e)
+            {
+                // ignore it, we're waiting for the unpacker to finish...
+            }
+        }
+        if (!unpacker.getResult()) { throw new InstallerException("Unpack failed (xml line "
+                + panelRoot.getLineNr() + ")"); }
+    }
 
-	/**
-	 * Sets state variable for thread sync.
-	 *
-	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#stopAction()
-	 */
-	public void stopAction() {
-		System.out.println("[ Unpacking finished ]");
-		boolean done = true;
-	}
+    /**
+     * Reports progress on System.out
+     *
+     * @see AbstractUIProgressHandler#startAction(String, int)
+     */
+    public void startAction(String name, int no_of_steps)
+    {
+        System.out.println("[ Starting to unpack ]");
+        this.noOfPacks = no_of_steps;
+    }
 
-	/**
-	 * Null op.
-	 *
-	 * @param val
-	 * @param msg
-	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#progress(int, String)
-	 */
-	public void progress(int val, String msg) {
-		// silent for now. should log individual files here, if we had a verbose
-		// mode?
-	}
+    /**
+     * Sets state variable for thread sync.
+     *
+     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#stopAction()
+     */
+    public void stopAction()
+    {
+        System.out.println("[ Unpacking finished ]");
+        boolean done = true;
+    }
 
-	/**
-	 * Reports progress to System.out
-	 *
-	 * @param packName The currently installing pack.
-	 * @param stepno   The number of the pack
-	 * @param stepsize unused
-	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#nextStep(String, int, int)
-	 */
-	public void nextStep(String packName, int stepno, int stepsize) {
-		System.out.print("[ Processing package: " + packName + " (");
-		System.out.print(stepno);
-		System.out.print('/');
-		System.out.print(this.noOfPacks);
-		System.out.println(") ]");
-	}
+    /**
+     * Null op.
+     *
+     * @param val
+     * @param msg
+     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#progress(int, String)
+     */
+    public void progress(int val, String msg)
+    {
+        // silent for now. should log individual files here, if we had a verbose
+        // mode?
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public void setSubStepNo(int no_of_substeps) {
-		// not used here
-	}
+    /**
+     * Reports progress to System.out
+     *
+     * @param packName The currently installing pack.
+     * @param stepno The number of the pack
+     * @param stepsize unused
+     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#nextStep(String, int, int)
+     */
+    public void nextStep(String packName, int stepno, int stepsize)
+    {
+        System.out.print("[ Processing package: " + packName + " (");
+        System.out.print(stepno);
+        System.out.print('/');
+        System.out.print(this.noOfPacks);
+        System.out.println(") ]");
+    }
 
-	@Override
-	public BindeableContainer getInstallerContainer() {
-		return installerContainer;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public void setSubStepNo(int no_of_substeps)
+    {
+        // not used here
+    }
 
-	@Override
-	public void setInstallerContainer(BindeableContainer installerContainer) {
-		this.installerContainer = installerContainer;
-	}
+    @Override
+    public BindeableContainer getInstallerContainer()
+    {
+        return installerContainer;
+    }
+
+    @Override
+    public void setInstallerContainer(BindeableContainer installerContainer)
+    {
+        this.installerContainer = installerContainer;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,11 +22,13 @@
 package com.izforge.izpack.panels.install;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.container.BindeableContainer;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.handler.AbstractUIProgressHandler;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 import com.izforge.izpack.installer.automation.PanelAutomationHelper;
+import com.izforge.izpack.installer.container.impl.InstallerContainer.HasInstallerContainer;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
 
 /**
@@ -34,115 +36,107 @@ import com.izforge.izpack.installer.unpacker.IUnpacker;
  *
  * @author Jonathan Halliday
  */
-public class InstallPanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation,
-        AbstractUIProgressHandler
-{
+public class InstallPanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation, AbstractUIProgressHandler, HasInstallerContainer {
 
-    private int noOfPacks = 0;
+	private BindeableContainer installerContainer;
+	private int noOfPacks = 0;
 
-    /**
-     * Null op - this panel type has no state to serialize.
-     *
-     * @param installData unused.
-     * @param panelRoot   unused.
-     */
-    public void makeXMLData(AutomatedInstallData installData, IXMLElement panelRoot)
-    {
-        // do nothing.
-    }
+	/**
+	 * Null op - this panel type has no state to serialize.
+	 *
+	 * @param installData unused.
+	 * @param panelRoot   unused.
+	 */
+	public void makeXMLData(AutomatedInstallData installData, IXMLElement panelRoot) {
+		// do nothing.
+	}
 
-    /**
-     * Perform the installation actions.
-     *
-     * @param panelRoot The panel XML tree root.
-     * @return true if the installation was successful.
-     */
-    public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot) throws InstallerException
-    {
-        /*
-        Unpacker unpacker = new Unpacker(installData, this);
-        unpacker.start();
-        */
-        //REFACTOR : Use container to get unpacker
-//        IUnpacker unpacker = UnpackerFactory.getUnpacker(idata.getInfo().getUnpackerClassName(), idata, this);
-        IUnpacker unpacker = null;
-        Thread unpackerthread = new Thread(unpacker, "IzPack - Unpacker thread");
-        unpacker.setRules(idata.getRules());
-        unpackerthread.start();
-        while (unpackerthread.isAlive())
-        {
-            try
-            {
-                Thread.sleep(100);
-            }
-            catch (InterruptedException e)
-            {
-                // ignore it, we're waiting for the unpacker to finish...
-            }
-        }
-        if (!unpacker.getResult())
-        {
-            throw new InstallerException("Unpack failed (xml line " + panelRoot.getLineNr() + ")");
-        }
-    }
+	/**
+	 * Perform the installation actions.
+	 *
+	 * @param panelRoot The panel XML tree root.
+	 * @return true if the installation was successful.
+	 */
+	public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot) throws InstallerException {
+		IUnpacker unpacker = installerContainer.getComponent(IUnpacker.class);
+		unpacker.setHandler(this);
+		Thread unpackerthread = new Thread(unpacker, "IzPack - Unpacker thread");
+		unpacker.setRules(idata.getRules());
+		unpackerthread.start();
+		while (unpackerthread.isAlive()) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				// ignore it, we're waiting for the unpacker to finish...
+			}
+		}
+		if (!unpacker.getResult()) {
+			throw new InstallerException("Unpack failed (xml line " + panelRoot.getLineNr() + ")");
+		}
+	}
 
-    /**
-     * Reports progress on System.out
-     *
-     * @see AbstractUIProgressHandler#startAction(String, int)
-     */
-    public void startAction(String name, int no_of_steps)
-    {
-        System.out.println("[ Starting to unpack ]");
-        this.noOfPacks = no_of_steps;
-    }
+	/**
+	 * Reports progress on System.out
+	 *
+	 * @see AbstractUIProgressHandler#startAction(String, int)
+	 */
+	public void startAction(String name, int no_of_steps) {
+		System.out.println("[ Starting to unpack ]");
+		this.noOfPacks = no_of_steps;
+	}
 
-    /**
-     * Sets state variable for thread sync.
-     *
-     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#stopAction()
-     */
-    public void stopAction()
-    {
-        System.out.println("[ Unpacking finished ]");
-        boolean done = true;
-    }
+	/**
+	 * Sets state variable for thread sync.
+	 *
+	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#stopAction()
+	 */
+	public void stopAction() {
+		System.out.println("[ Unpacking finished ]");
+		boolean done = true;
+	}
 
-    /**
-     * Null op.
-     *
-     * @param val
-     * @param msg
-     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#progress(int, String)
-     */
-    public void progress(int val, String msg)
-    {
-        // silent for now. should log individual files here, if we had a verbose
-        // mode?
-    }
+	/**
+	 * Null op.
+	 *
+	 * @param val
+	 * @param msg
+	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#progress(int, String)
+	 */
+	public void progress(int val, String msg) {
+		// silent for now. should log individual files here, if we had a verbose
+		// mode?
+	}
 
-    /**
-     * Reports progress to System.out
-     *
-     * @param packName The currently installing pack.
-     * @param stepno   The number of the pack
-     * @param stepsize unused
-     * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#nextStep(String, int, int)
-     */
-    public void nextStep(String packName, int stepno, int stepsize)
-    {
-        System.out.print("[ Processing package: " + packName + " (");
-        System.out.print(stepno);
-        System.out.print('/');
-        System.out.print(this.noOfPacks);
-        System.out.println(") ]");
-    }
+	/**
+	 * Reports progress to System.out
+	 *
+	 * @param packName The currently installing pack.
+	 * @param stepno   The number of the pack
+	 * @param stepsize unused
+	 * @see com.izforge.izpack.api.handler.AbstractUIProgressHandler#nextStep(String, int, int)
+	 */
+	public void nextStep(String packName, int stepno, int stepsize) {
+		System.out.print("[ Processing package: " + packName + " (");
+		System.out.print(stepno);
+		System.out.print('/');
+		System.out.print(this.noOfPacks);
+		System.out.println(") ]");
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    public void setSubStepNo(int no_of_substeps)
-    {
-        // not used here
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	public void setSubStepNo(int no_of_substeps) {
+		// not used here
+	}
+
+	@Override
+	public BindeableContainer getInstallerContainer() {
+		return installerContainer;
+	}
+
+	@Override
+	public void setInstallerContainer(BindeableContainer installerContainer) {
+		this.installerContainer = installerContainer;
+	}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelConsoleHelper.java
@@ -42,11 +42,12 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
         AbstractUIProgressHandler, HasInstallerContainer
 {
 
-	private BindeableContainer installerContainer;
+    private BindeableContainer installerContainer;
+
     private int noOfPacks = 0;
 
-
-    public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter)
+    public boolean runGeneratePropertiesFile(AutomatedInstallData installData,
+            PrintWriter printWriter)
     {
         return true;
     }
@@ -79,12 +80,13 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
 
     }
 
-
+    @Override
     public void emitNotification(String message)
     {
         System.out.println(message);
     }
 
+    @Override
     public boolean emitWarning(String title, String message)
     {
         System.err.println("[ WARNING: " + message + " ]");
@@ -92,22 +94,26 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
         return true;
     }
 
+    @Override
     public void emitError(String title, String message)
     {
         System.err.println("[ ERROR: " + message + " ]");
     }
 
+    @Override
     public void emitErrorAndBlockNext(String title, String message)
     {
         System.err.println("[ ERROR: " + message + " ]");
     }
 
+    @Override
     public int askQuestion(String title, String question, int choices)
     {
         // don't know what to answer
         return AbstractUIHandler.ANSWER_CANCEL;
     }
 
+    @Override
     public int askQuestion(String title, String question, int choices, int default_choice)
     {
         return default_choice;
@@ -144,13 +150,15 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
 
     }
 
-	@Override
-	public BindeableContainer getInstallerContainer() {
-		return installerContainer;
-	}
+    @Override
+    public BindeableContainer getInstallerContainer()
+    {
+        return installerContainer;
+    }
 
-	@Override
-	public void setInstallerContainer(BindeableContainer installerContainer) {
-		this.installerContainer = installerContainer;
-	}
+    @Override
+    public void setInstallerContainer(BindeableContainer installerContainer)
+    {
+        this.installerContainer = installerContainer;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelConsoleHelper.java
@@ -21,15 +21,17 @@
 
 package com.izforge.izpack.panels.install;
 
+import java.io.PrintWriter;
+import java.util.Properties;
+
+import com.izforge.izpack.api.container.BindeableContainer;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.handler.AbstractUIProgressHandler;
 import com.izforge.izpack.installer.console.PanelConsole;
 import com.izforge.izpack.installer.console.PanelConsoleHelper;
+import com.izforge.izpack.installer.container.impl.InstallerContainer.HasInstallerContainer;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
-
-import java.io.PrintWriter;
-import java.util.Properties;
 
 /**
  * Install Panel console helper
@@ -37,9 +39,10 @@ import java.util.Properties;
  * @author Mounir el hajj
  */
 public class InstallPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole,
-        AbstractUIProgressHandler
+        AbstractUIProgressHandler, HasInstallerContainer
 {
 
+	private BindeableContainer installerContainer;
     private int noOfPacks = 0;
 
 
@@ -55,11 +58,8 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
 
     public boolean runConsole(AutomatedInstallData idata)
     {
-
-        //REFACTOR : Use container to get unpacker
-//        IUnpacker unpacker = UnpackerFactory.getUnpacker(idata.getInfo().getUnpackerClassName(), idata, this);
-//                this);
-        IUnpacker unpacker = null;
+        IUnpacker unpacker = installerContainer.getComponent(IUnpacker.class);
+        unpacker.setHandler(this);
         Thread unpackerthread = new Thread(unpacker, "IzPack - Unpacker thread");
         unpacker.setRules(idata.getRules());
         unpackerthread.start();
@@ -143,4 +143,14 @@ public class InstallPanelConsoleHelper extends PanelConsoleHelper implements Pan
     {
 
     }
+
+	@Override
+	public BindeableContainer getInstallerContainer() {
+		return installerContainer;
+	}
+
+	@Override
+	public void setInstallerContainer(BindeableContainer installerContainer) {
+		this.installerContainer = installerContainer;
+	}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelConsoleHelper.java
@@ -49,12 +49,17 @@ import com.izforge.izpack.util.OsVersion;
  */
 public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole
 {
+
     private String minVersion;
+
     private String maxVersion;
+
     private String variableName;
+
     private String detectedVersion;
 
-    public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter)
+    public boolean runGeneratePropertiesFile(AutomatedInstallData installData,
+            PrintWriter printWriter)
     {
         printWriter.println(AutomatedInstallData.INSTALL_PATH + "=");
         return true;
@@ -107,7 +112,8 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
         if (!pathIsValid(strDefaultPath) || !verifyVersion(minVersion, maxVersion, strDefaultPath))
         {
             strDefaultPath = resolveInRegistry(minVersion, maxVersion);
-            if (!pathIsValid(strDefaultPath) || !verifyVersion(minVersion, maxVersion, strDefaultPath))
+            if (!pathIsValid(strDefaultPath)
+                    || !verifyVersion(minVersion, maxVersion, strDefaultPath))
             {
                 strDefaultPath = "";
             }
@@ -142,13 +148,15 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
             }
             else if (!verifyVersion(minVersion, maxVersion, strPath))
             {
-                System.out.println("The chosen JDK has the wrong version (available: " + detectedVersion + " required: " + minVersion + " - " + maxVersion + ").");
+                System.out.println("The chosen JDK has the wrong version (available: "
+                        + detectedVersion + " required: " + minVersion + " - " + maxVersion + ").");
                 System.out.println("Continue anyway? [no]");
                 br = new BufferedReader(new InputStreamReader(System.in));
                 try
                 {
                     String strIn = br.readLine();
-                    if (strIn.trim().toLowerCase().equals("y") || strIn.trim().toLowerCase().equals("yes"))
+                    if (strIn.trim().toLowerCase().equals("y")
+                            || strIn.trim().toLowerCase().equals("yes"))
                     {
                         bKeepAsking = false;
                     }
@@ -184,8 +192,8 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
 
     /**
      * Returns whether the chosen path is true or not. If existFiles are not null, the existence of
-     * it under the chosen path are detected. This method can be also implemented in derived
-     * classes to handle special verification of the path.
+     * it under the chosen path are detected. This method can be also implemented in derived classes
+     * to handle special verification of the path.
      *
      * @return true if existFiles are exist or not defined, else false
      */
@@ -194,10 +202,7 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
         for (String existFile : JDKPathPanel.testFiles)
         {
             File path = new File(strPath, existFile).getAbsoluteFile();
-            if (!path.exists())
-            {
-                return false;
-            }
+            if (!path.exists()) { return false; }
         }
         return true;
     }
@@ -206,30 +211,21 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
     {
         boolean retval = true;
         // No min and max, version always ok.
-        if (min == null && max == null)
-        {
-            return (true);
-        }
+        if (min == null && max == null) { return (true); }
         // Now get the version ...
         // We cannot look to the version of this vm because we should
         // test the given JDK VM.
         String[] params;
         if (System.getProperty("os.name").contains("Windows"))
         {
-            String[] paramsp = {
-                    "cmd",
-                    "/c",
-                    path + File.separator + "bin" + File.separator + "java",
-                    "-version"
-            };
+            String[] paramsp = { "cmd", "/c",
+                    path + File.separator + "bin" + File.separator + "java", "-version"};
             params = paramsp;
         }
         else
         {
-            String[] paramsp = {
-                    path + File.separator + "bin" + File.separator + "java",
-                    "-version"
-            };
+            String[] paramsp = { path + File.separator + "bin" + File.separator + "java",
+                    "-version"};
             params = paramsp;
         }
         String[] output = new String[2];
@@ -254,8 +250,8 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
         return retval;
     }
 
-    private boolean compareVersions(String in, String template, boolean isMin,
-                                    int assumedPlace, int halfRange, String useNotIdentifier)
+    private boolean compareVersions(String in, String template, boolean isMin, int assumedPlace,
+            int halfRange, String useNotIdentifier)
     {
         StringTokenizer tokenizer = new StringTokenizer(in, " \t\n\r\f\"");
         int i;
@@ -306,10 +302,7 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
             // will be right here. Only if e.g. needed is 1.4.2_00 the
             // return value will be false, but zero should not b e used
             // at the last version part.
-            if (!currentTokenizer.hasMoreTokens())
-            {
-                return (false);
-            }
+            if (!currentTokenizer.hasMoreTokens()) { return (false); }
             String current = currentTokenizer.nextToken();
             String needed = neededTokenizer.nextToken();
             int currentValue = 0;
@@ -321,28 +314,22 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
             }
             catch (NumberFormatException nfe)
             { // A number format exception will be raised if
-                // there is a non numeric part in the version,
-                // e.g. 1.5.0_beta. The verification runs only into
-                // this deep area of version number (fourth sub place)
-                // if all other are equal to the given limit. Then
-                // it is right to return false because e.g.
-                // the minimal needed version will be 1.5.0.2.
+              // there is a non numeric part in the version,
+              // e.g. 1.5.0_beta. The verification runs only into
+              // this deep area of version number (fourth sub place)
+              // if all other are equal to the given limit. Then
+              // it is right to return false because e.g.
+              // the minimal needed version will be 1.5.0.2.
                 return (false);
             }
             if (currentValue < neededValue)
             {
-                if (isMin)
-                {
-                    return (false);
-                }
+                if (isMin) { return (false); }
                 return (true);
             }
             if (currentValue > neededValue)
             {
-                if (isMin)
-                {
-                    return (true);
-                }
+                if (isMin) { return (true); }
                 return (false);
             }
         }
@@ -371,28 +358,26 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
             // We are on a os which has no registry or the
             // needed dll was not bound to this installation. In
             // both cases we forget the try to get the JDK path from registry.
-            {
-                return (retval);
-            }
+            { return (retval); }
             oldVal = registryHandler.getRoot(); // Only for security...
             registryHandler.setRoot(MSWinConstants.HKEY_LOCAL_MACHINE);
             String[] keys = registryHandler.getSubkeys(JDKPathPanel.JDK_ROOT_KEY);
-            if (keys == null || keys.length == 0)
-            {
-                return (retval);
-            }
+            if (keys == null || keys.length == 0) { return (retval); }
             Arrays.sort(keys);
             int i = keys.length - 1;
             // We search for the highest allowd version, therefore retrograde
             while (i > 0)
             {
-                if (max == null || compareVersions(keys[i], max, false, 4, 4, "__NO_NOT_IDENTIFIER_"))
+                if (max == null
+                        || compareVersions(keys[i], max, false, 4, 4, "__NO_NOT_IDENTIFIER_"))
                 { // First allowed version found, now we have to test that the min value
-                    // also allows this version.
-                    if (min == null || compareVersions(keys[i], min, true, 4, 4, "__NO_NOT_IDENTIFIER_"))
+                  // also allows this version.
+                    if (min == null
+                            || compareVersions(keys[i], min, true, 4, 4, "__NO_NOT_IDENTIFIER_"))
                     {
                         String cv = JDKPathPanel.JDK_ROOT_KEY + "\\" + keys[i];
-                        String path = registryHandler.getValue(cv, JDKPathPanel.JDK_VALUE_NAME).getStringData();
+                        String path = registryHandler.getValue(cv, JDKPathPanel.JDK_VALUE_NAME)
+                                .getStringData();
                         // Use it only if the path is valid.
                         // Set the path for method pathIsValid ...
                         if (!pathIsValid(path))
@@ -410,7 +395,7 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
         }
         catch (Exception e)
         { // Will only be happen if registry handler is good, but an
-            // exception at performing was thrown. This is an error...
+          // exception at performing was thrown. This is an error...
             e.printStackTrace();
         }
         finally

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelConsoleHelper.java
@@ -21,19 +21,26 @@
 
 package com.izforge.izpack.panels.jdkpath;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringTokenizer;
+
 import com.coi.tools.os.win.MSWinConstants;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
-import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.installer.console.PanelConsole;
 import com.izforge.izpack.installer.console.PanelConsoleHelper;
 import com.izforge.izpack.util.FileExecutor;
 import com.izforge.izpack.util.OsVersion;
-
-import java.io.*;
-import java.util.*;
 
 /**
  * The Target panel console helper class.
@@ -46,12 +53,6 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
     private String maxVersion;
     private String variableName;
     private String detectedVersion;
-    private VariableSubstitutor variableSubstitutor;
-
-    public JDKPathPanelConsoleHelper(VariableSubstitutor variableSubstitutor)
-    {
-        this.variableSubstitutor = variableSubstitutor;
-    }
 
     public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter)
     {
@@ -71,7 +72,7 @@ public class JDKPathPanelConsoleHelper extends PanelConsoleHelper implements Pan
         {
             try
             {
-                strTargetPath = variableSubstitutor.substitute(strTargetPath);
+                strTargetPath = getVariableSubstitutor(installData).substitute(strTargetPath);
             }
             catch (Exception e)
             {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelConsoleHelper.java
@@ -1,0 +1,92 @@
+package com.izforge.izpack.panels.process;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Properties;
+
+import com.izforge.izpack.api.container.BindeableContainer;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.handler.AbstractUIProcessHandler;
+import com.izforge.izpack.api.rules.RulesEngine;
+import com.izforge.izpack.api.substitutor.VariableSubstitutor;
+import com.izforge.izpack.installer.console.PanelConsole;
+import com.izforge.izpack.installer.console.PanelConsoleHelper;
+import com.izforge.izpack.installer.container.impl.InstallerContainer.HasInstallerContainer;
+
+public class ProcessPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole, AbstractUIProcessHandler, HasInstallerContainer {
+
+	private BindeableContainer installerContainer;
+	private int noOfJobs = 0;
+	private int currentJob = 0;
+
+	@Override
+	public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter) {
+		return true;
+	}
+
+	@Override
+	public boolean runConsoleFromProperties(AutomatedInstallData installData, Properties p) {
+		return runConsole(installData);
+	}
+
+	@Override
+	public boolean runConsole(AutomatedInstallData installData) {
+		ProcessPanelWorker worker = createWorker(installData);
+		worker.run();
+		if (!worker.getResult()) throw new RuntimeException("The work done by the ProcessPanel failed");
+		return true;
+	}
+
+	private ProcessPanelWorker createWorker(AutomatedInstallData installData) {
+		if (installerContainer == null) throw new NullPointerException("Missing installer container");
+		noOfJobs = currentJob = 0; //reset variables
+
+		RulesEngine rules = installerContainer.getComponent(RulesEngine.class);
+		VariableSubstitutor substitutor = installerContainer.getComponent(VariableSubstitutor.class);
+		try {
+			ProcessPanelWorker worker = new ProcessPanelWorker(installData, substitutor, rules);
+			worker.setHandler(this);
+			return worker;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void logOutput(String message, boolean stderr) {
+		if (stderr) System.err.println(message);
+		else System.out.println(message);
+	}
+
+	@Override
+	public void startProcessing(int no_of_processes) {
+		System.out.println("[ Starting processing ]");
+		this.noOfJobs = no_of_processes;
+	}
+
+	@Override
+	public void startProcess(String name) {
+		this.currentJob++;
+		System.out.println("Starting process " + name + " (" + this.currentJob + "/" + this.noOfJobs + ")");
+	}
+
+	@Override
+	public void finishProcess() {
+	}
+
+	@Override
+	public void finishProcessing(boolean unlockPrev, boolean unlockNext) {
+		if (!unlockNext) throw new IllegalStateException("Process failed");
+		System.out.println("[ Processing finished ]");
+	}
+
+	@Override
+	public BindeableContainer getInstallerContainer() {
+		return installerContainer;
+	}
+
+	@Override
+	public void setInstallerContainer(BindeableContainer installerContainer) {
+		this.installerContainer = installerContainer;
+	}
+}

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelConsoleHelper.java
@@ -13,80 +13,105 @@ import com.izforge.izpack.installer.console.PanelConsole;
 import com.izforge.izpack.installer.console.PanelConsoleHelper;
 import com.izforge.izpack.installer.container.impl.InstallerContainer.HasInstallerContainer;
 
-public class ProcessPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole, AbstractUIProcessHandler, HasInstallerContainer {
+public class ProcessPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole,
+        AbstractUIProcessHandler, HasInstallerContainer
+{
 
-	private BindeableContainer installerContainer;
-	private int noOfJobs = 0;
-	private int currentJob = 0;
+    private BindeableContainer installerContainer;
 
-	@Override
-	public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter) {
-		return true;
-	}
+    private int noOfJobs = 0;
 
-	@Override
-	public boolean runConsoleFromProperties(AutomatedInstallData installData, Properties p) {
-		return runConsole(installData);
-	}
+    private int currentJob = 0;
 
-	@Override
-	public boolean runConsole(AutomatedInstallData installData) {
-		ProcessPanelWorker worker = createWorker(installData);
-		worker.run();
-		if (!worker.getResult()) throw new RuntimeException("The work done by the ProcessPanel failed");
-		return true;
-	}
+    @Override
+    public boolean runGeneratePropertiesFile(AutomatedInstallData installData,
+            PrintWriter printWriter)
+    {
+        return true;
+    }
 
-	private ProcessPanelWorker createWorker(AutomatedInstallData installData) {
-		if (installerContainer == null) throw new NullPointerException("Missing installer container");
-		noOfJobs = currentJob = 0; //reset variables
+    @Override
+    public boolean runConsoleFromProperties(AutomatedInstallData installData, Properties p)
+    {
+        return runConsole(installData);
+    }
 
-		RulesEngine rules = installerContainer.getComponent(RulesEngine.class);
-		VariableSubstitutor substitutor = installerContainer.getComponent(VariableSubstitutor.class);
-		try {
-			ProcessPanelWorker worker = new ProcessPanelWorker(installData, substitutor, rules);
-			worker.setHandler(this);
-			return worker;
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    @Override
+    public boolean runConsole(AutomatedInstallData installData)
+    {
+        ProcessPanelWorker worker = createWorker(installData);
+        worker.run();
+        if (!worker.getResult())
+            throw new RuntimeException("The work done by the ProcessPanel failed");
+        return true;
+    }
 
-	@Override
-	public void logOutput(String message, boolean stderr) {
-		if (stderr) System.err.println(message);
-		else System.out.println(message);
-	}
+    private ProcessPanelWorker createWorker(AutomatedInstallData installData)
+    {
+        if (installerContainer == null)
+            throw new NullPointerException("Missing installer container");
+        noOfJobs = currentJob = 0; // reset variables
 
-	@Override
-	public void startProcessing(int no_of_processes) {
-		System.out.println("[ Starting processing ]");
-		this.noOfJobs = no_of_processes;
-	}
+        RulesEngine rules = installerContainer.getComponent(RulesEngine.class);
+        VariableSubstitutor substitutor = installerContainer
+                .getComponent(VariableSubstitutor.class);
+        try
+        {
+            ProcessPanelWorker worker = new ProcessPanelWorker(installData, substitutor, rules);
+            worker.setHandler(this);
+            return worker;
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
 
-	@Override
-	public void startProcess(String name) {
-		this.currentJob++;
-		System.out.println("Starting process " + name + " (" + this.currentJob + "/" + this.noOfJobs + ")");
-	}
+    @Override
+    public void logOutput(String message, boolean stderr)
+    {
+        if (stderr)
+            System.err.println(message);
+        else
+            System.out.println(message);
+    }
 
-	@Override
-	public void finishProcess() {
-	}
+    @Override
+    public void startProcessing(int no_of_processes)
+    {
+        System.out.println("[ Starting processing ]");
+        this.noOfJobs = no_of_processes;
+    }
 
-	@Override
-	public void finishProcessing(boolean unlockPrev, boolean unlockNext) {
-		if (!unlockNext) throw new IllegalStateException("Process failed");
-		System.out.println("[ Processing finished ]");
-	}
+    @Override
+    public void startProcess(String name)
+    {
+        this.currentJob++;
+        System.out.println("Starting process " + name + " (" + this.currentJob + "/"
+                + this.noOfJobs + ")");
+    }
 
-	@Override
-	public BindeableContainer getInstallerContainer() {
-		return installerContainer;
-	}
+    @Override
+    public void finishProcess()
+    {
+    }
 
-	@Override
-	public void setInstallerContainer(BindeableContainer installerContainer) {
-		this.installerContainer = installerContainer;
-	}
+    @Override
+    public void finishProcessing(boolean unlockPrev, boolean unlockNext)
+    {
+        if (!unlockNext) throw new IllegalStateException("Process failed");
+        System.out.println("[ Processing finished ]");
+    }
+
+    @Override
+    public BindeableContainer getInstallerContainer()
+    {
+        return installerContainer;
+    }
+
+    @Override
+    public void setInstallerContainer(BindeableContainer installerContainer)
+    {
+        this.installerContainer = installerContainer;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
@@ -304,7 +304,11 @@ public class ProcessPanelWorker implements Runnable
 
         for (ProcessPanelWorker.ProcessingJob processingJob : this.jobs)
         {
-            this.handler.startProcess(processingJob.name);
+        	String jobMessageKey = ProcessPanel.class.getSimpleName() + ".job." + processingJob.name;
+			String jobName = idata.getLangpack().getString(jobMessageKey);
+        	if (jobName == jobMessageKey) jobName = processingJob.name;
+
+            this.handler.startProcess(jobName);
 
             this.result = processingJob.run(this.handler, this.vs);
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelConsoleHelper.java
@@ -40,7 +40,9 @@ import com.izforge.izpack.panels.path.PathInputPanel;
  */
 public class TargetPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole
 {
-    public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter)
+
+    public boolean runGeneratePropertiesFile(AutomatedInstallData installData,
+            PrintWriter printWriter)
     {
         printWriter.println(AutomatedInstallData.INSTALL_PATH + "=");
         return true;
@@ -73,8 +75,8 @@ public class TargetPanelConsoleHelper extends PanelConsoleHelper implements Pane
     {
 
         ResourceManager resourceManager = ResourceManager.getInstance();
-        String strDefaultPath = PathInputPanel.loadDefaultInstallDir(
-                resourceManager, getVariableSubstitutor(idata), idata);
+        String strDefaultPath = PathInputPanel.loadDefaultInstallDir(resourceManager,
+                getVariableSubstitutor(idata), idata);
 
         String strTargetPath = "";
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelConsoleHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelConsoleHelper.java
@@ -21,18 +21,17 @@
 
 package com.izforge.izpack.panels.target;
 
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.ResourceManager;
-import com.izforge.izpack.api.substitutor.VariableSubstitutor;
-import com.izforge.izpack.installer.console.PanelConsole;
-import com.izforge.izpack.installer.console.PanelConsoleHelper;
-import com.izforge.izpack.panels.path.PathInputPanel;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.Properties;
+
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.ResourceManager;
+import com.izforge.izpack.installer.console.PanelConsole;
+import com.izforge.izpack.installer.console.PanelConsoleHelper;
+import com.izforge.izpack.panels.path.PathInputPanel;
 
 /**
  * The Target panel console helper class.
@@ -41,13 +40,6 @@ import java.util.Properties;
  */
 public class TargetPanelConsoleHelper extends PanelConsoleHelper implements PanelConsole
 {
-    private VariableSubstitutor variableSubstitutor;
-
-    public TargetPanelConsoleHelper(VariableSubstitutor variableSubstitutor)
-    {
-        this.variableSubstitutor = variableSubstitutor;
-    }
-
     public boolean runGeneratePropertiesFile(AutomatedInstallData installData, PrintWriter printWriter)
     {
         printWriter.println(AutomatedInstallData.INSTALL_PATH + "=");
@@ -66,7 +58,7 @@ public class TargetPanelConsoleHelper extends PanelConsoleHelper implements Pane
         {
             try
             {
-                strTargetPath = variableSubstitutor.substitute(strTargetPath);
+                strTargetPath = getVariableSubstitutor(installData).substitute(strTargetPath);
             }
             catch (Exception e)
             {
@@ -82,7 +74,7 @@ public class TargetPanelConsoleHelper extends PanelConsoleHelper implements Pane
 
         ResourceManager resourceManager = ResourceManager.getInstance();
         String strDefaultPath = PathInputPanel.loadDefaultInstallDir(
-                resourceManager, variableSubstitutor, idata);
+                resourceManager, getVariableSubstitutor(idata), idata);
 
         String strTargetPath = "";
 
@@ -108,7 +100,7 @@ public class TargetPanelConsoleHelper extends PanelConsoleHelper implements Pane
 
         try
         {
-            strTargetPath = variableSubstitutor.substitute(strTargetPath);
+            strTargetPath = getVariableSubstitutor(idata).substitute(strTargetPath);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
I added call for method _com.izforge.izpack.installer.base.InstallerBase.refreshDynamicVariables(AutomatedInstallData, VariableSubstitutor...)_ into console installer before panels processing action. {color:blue}NOTE:{color} same principe as in com.izforge.izpack.installer.automation.AutomatedInstaller.doInstall()
