### PR TITLE
Launch application after installation has finished (patch).

### DIFF
--- a/bin/langpacks/installer/eng.xml
+++ b/bin/langpacks/installer/eng.xml
@@ -134,6 +134,8 @@
     <str id="FinishPanel.auto" txt="Generate an automatic installation script"/>
     <str id="FinishPanel.auto.tip" txt="Use this script to repeat this installation on other computers."/>
     <str id="FinishPanel.auto.dialog.filterdesc" txt="XML Files"/>
+    <str id="FinishPanel.launchAfterInstall" txt="<launch application text>"/>
+    <str id="FinishPanel.launchAfterInstall.fail" txt="<launch application fail text>"/>
 
 		<!-- ImgPacksPanel strings -->
 		<str id="ImgPacksPanel.dependencyList" txt="Dependencies and/or excludes"/>

--- a/src/lib/com/izforge/izpack/installer/InstallerFrame.java
+++ b/src/lib/com/izforge/izpack/installer/InstallerFrame.java
@@ -1581,6 +1581,24 @@ public class InstallerFrame extends JFrame {
             } else if (source == nextButton) {
                 navigateNext();
             } else if (source == quitButton) {
+                if(((JButton)source).getText().equals("Done"))
+                {
+                    String launchApplication = installdata.getVariable("launch_app_after_install");
+                    if (launchApplication != null && launchApplication.equals("on"))
+                    {
+                        InstallerFrame.this.setVisible(false);
+                        try
+                        {
+                            Runtime.getRuntime().exec(
+                                    new File(installdata.getInstallPath() + installdata.getVariable("path_to_executable_in_install_dir")).getPath());
+                        }
+                        catch (IOException IOEx)
+                        {
+                            JOptionPane.showMessageDialog(InstallerFrame.this, IOEx.getMessage(),
+                                    installdata.langpack.getString("FinishPanel.launchAfterInstall.fail"), 0);
+                        }
+                    }
+                }
                 exit();
             }
         }

--- a/src/lib/com/izforge/izpack/panels/FinishPanel.java
+++ b/src/lib/com/izforge/izpack/panels/FinishPanel.java
@@ -24,11 +24,14 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -145,6 +148,30 @@ public class FinishPanel extends IzPanel implements ActionListener
             constraints.gridx = 0;
             add(autoButton, constraints);
  
+            JCheckBox check = new JCheckBox(
+                    parent.langpack.getString("FinishPanel.launchAfterInstall"));
+            check.setSelected(false);
+            idata.setVariable("launch_app_after_install", "off");
+            check.addItemListener(new ItemListener() {
+
+                public void itemStateChanged(ItemEvent e)
+                {
+                    if (e.getStateChange() == ItemEvent.SELECTED)
+                    {
+                        idata.setVariable("launch_app_after_install", "on");
+                    }
+                    else
+                    {
+                        idata.setVariable("launch_app_after_install", "off");
+                    }
+                }
+            });
+            constraints.gridx = 0;
+            constraints.insets = new Insets(50, 0, 0, 0); // add padding between the launch
+                                                          // application checkbox and the
+                                                          // previous
+                                                          // element
+            add(check, constraints);
         }
         else
         {


### PR DESCRIPTION
Launch application after installation has finished (patch):
- need to define some specific FinishPanel messages (included only
  for the English version)
- need to define also a variable
  ("path_to_executable_in_install_dir") for the path to the executable
  itself, inside the specified installation directory (this could be
  improved)
